### PR TITLE
fix: xdg_surface configure serial

### DIFF
--- a/src/ifs/wl_surface/xdg_surface.rs
+++ b/src/ifs/wl_surface/xdg_surface.rs
@@ -347,7 +347,7 @@ impl SurfaceExt for XdgSurface {
                     if let Some(ext) = self.ext.get() {
                         ext.initial_configure()?;
                     }
-                    self.send_configure(rse + 1);
+                    self.send_configure(rse);
                 }
                 // return CommitAction::AbortCommit;
             }

--- a/src/ifs/wl_surface/xdg_surface.rs
+++ b/src/ifs/wl_surface/xdg_surface.rs
@@ -96,7 +96,7 @@ impl XdgSurface {
             base: wm_base.clone(),
             role: Cell::new(XdgSurfaceRole::None),
             surface: surface.clone(),
-            requested_serial: NumCell::new(0),
+            requested_serial: NumCell::new(1),
             acked_serial: Cell::new(None),
             geometry: Cell::new(None),
             extents: Cell::new(Default::default()),

--- a/src/ifs/wl_surface/xdg_surface.rs
+++ b/src/ifs/wl_surface/xdg_surface.rs
@@ -347,7 +347,7 @@ impl SurfaceExt for XdgSurface {
                     if let Some(ext) = self.ext.get() {
                         ext.initial_configure()?;
                     }
-                    self.send_configure(rse);
+                    self.send_configure(rse + 1);
                 }
                 // return CommitAction::AbortCommit;
             }


### PR DESCRIPTION
Some applications, like Telegram Desktop, won't send `ack_configure` if the `serial` value in the corresponding `configure` event is 0. Because of that, Telegram's window wasn't showing.

I don't know why Telegram interprets the 0 as some special value of the `serial`.
However, if the `serial` starts with 1, Telegram suddenly works (i.e., it shows the window).