### PR TITLE
config: downgrade bincode to 1.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,21 +153,11 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "2.0.0-rc.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "bincode_derive",
  "serde",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -533,6 +523,7 @@ dependencies = [
  "pin-project",
  "rand",
  "repc",
+ "serde",
  "shaderc",
  "smallvec",
  "thiserror",
@@ -545,6 +536,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "log",
+ "serde",
 ]
 
 [[package]]
@@ -1056,12 +1048,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "virtue"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.19.0"
 rand = "0.8.5"
 smallvec = { version = "1.11.1", features = ["const_generics", "const_new", "union"] }
 byteorder = "1.5.0"
-bincode = "2.0.0-rc.3"
+bincode = "1.3.3"
 jay-config = { path = "jay-config" }
 default-config = { path = "default-config" }
 algorithms = { path = "algorithms" }
@@ -46,6 +46,7 @@ indexmap = "2.2.0"
 ash = "0.37.3"
 gpu-alloc = "0.6.0"
 gpu-alloc-ash = "0.6.0"
+serde = { version = "1.0.196", features = ["derive"] }
 
 [build-dependencies]
 repc = "0.1.1"

--- a/jay-config/Cargo.toml
+++ b/jay-config/Cargo.toml
@@ -6,5 +6,6 @@ license = "GPL-3.0-only"
 description = "Configuration crate for the Jay compositor"
 
 [dependencies]
-bincode = "2.0.0-rc.1"
+bincode = "1.3.3"
+serde = { version = "1.0.196", features = ["derive"] }
 log = "0.4.14"

--- a/jay-config/src/_private.rs
+++ b/jay-config/src/_private.rs
@@ -2,7 +2,7 @@ pub mod client;
 pub mod ipc;
 mod logging;
 
-use std::marker::PhantomData;
+use {bincode::Options, std::marker::PhantomData};
 
 pub const VERSION: u32 = 1;
 
@@ -26,9 +26,9 @@ pub struct ConfigEntryGen<T> {
 
 impl<T: Config> ConfigEntryGen<T> {}
 
-pub fn bincode_ops() -> impl bincode::config::Config {
-    bincode::config::standard()
-        .with_fixed_int_encoding()
+pub fn bincode_ops() -> impl Options {
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
         .with_little_endian()
         .with_no_limit()
 }

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -8,11 +8,11 @@ use {
         video::{connector_type::ConnectorType, Connector, DrmDevice, GfxApi},
         Axis, Direction, PciId, Workspace,
     },
-    bincode::{BorrowDecode, Decode, Encode},
+    serde::{Deserialize, Serialize},
     std::time::Duration,
 };
 
-#[derive(Encode, BorrowDecode, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum ServerMessage {
     Configure {
         reload: bool,
@@ -58,7 +58,7 @@ pub enum ServerMessage {
     DevicesEnumerated,
 }
 
-#[derive(Encode, BorrowDecode, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum ClientMessage<'a> {
     Reload,
     Quit,
@@ -340,7 +340,7 @@ pub enum ClientMessage<'a> {
     },
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum Response {
     None,
     GetSeats {
@@ -442,10 +442,10 @@ pub enum Response {
     },
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum InitMessage {
     V1(V1InitMessage),
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct V1InitMessage {}

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -9,11 +9,11 @@ use {
         keyboard::Keymap,
         Axis, Direction, ModifiedKeySym, Workspace,
     },
-    bincode::{Decode, Encode},
+    serde::{Deserialize, Serialize},
 };
 
 /// An input device.
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct InputDevice(pub u64);
 
 impl InputDevice {
@@ -114,7 +114,7 @@ impl InputDevice {
 }
 
 /// A seat.
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Seat(pub u64);
 
 impl Seat {

--- a/jay-config/src/input/acceleration.rs
+++ b/jay-config/src/input/acceleration.rs
@@ -2,10 +2,10 @@
 //!
 //! See the libinput documentation for details.
 
-use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 
 /// The acceleration profile of a device.
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct AccelProfile(pub u32);
 
 /// A flat acceleration profile.

--- a/jay-config/src/input/capability.rs
+++ b/jay-config/src/input/capability.rs
@@ -2,10 +2,10 @@
 //!
 //! See the libinput documentation for the meanings of these constants.
 
-use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 
 /// A capability of an input device.
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Capability(pub u32);
 
 pub const CAP_KEYBOARD: Capability = Capability(0);

--- a/jay-config/src/keyboard/mod.rs
+++ b/jay-config/src/keyboard/mod.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::keyboard::{mods::Modifiers, syms::KeySym},
-    bincode::{Decode, Encode},
+    serde::{Deserialize, Serialize},
     std::ops::{BitOr, BitOrAssign},
 };
 
@@ -10,7 +10,7 @@ pub mod mods;
 pub mod syms;
 
 /// A keysym with zero or more modifiers
-#[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct ModifiedKeySym {
     pub mods: Modifiers,
     pub sym: KeySym,
@@ -43,7 +43,7 @@ impl BitOrAssign<Modifiers> for ModifiedKeySym {
 }
 
 /// A keymap.
-#[derive(Encode, Decode, Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Keymap(pub u64);
 
 impl Keymap {

--- a/jay-config/src/keyboard/mods.rs
+++ b/jay-config/src/keyboard/mods.rs
@@ -2,12 +2,12 @@
 
 use {
     crate::{keyboard::syms::KeySym, ModifiedKeySym},
-    bincode::{Decode, Encode},
+    serde::{Deserialize, Serialize},
     std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign},
 };
 
 /// Zero or more keyboard modifiers
-#[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, Default, Hash, Debug)]
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Default, Hash, Debug)]
 pub struct Modifiers(pub u32);
 
 /// The Shift modifier

--- a/jay-config/src/keyboard/syms.rs
+++ b/jay-config/src/keyboard/syms.rs
@@ -2,10 +2,10 @@
 
 #![allow(non_upper_case_globals)]
 
-use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 
 /// A keysym.
-#[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct KeySym(pub u32);
 
 pub const SYM_BackSpace: KeySym = KeySym(0xff08);

--- a/jay-config/src/lib.rs
+++ b/jay-config/src/lib.rs
@@ -42,7 +42,7 @@
 
 use {
     crate::keyboard::ModifiedKeySym,
-    bincode::{Decode, Encode},
+    serde::{Deserialize, Serialize},
     std::fmt::{Debug, Display, Formatter},
 };
 
@@ -61,7 +61,7 @@ pub mod timer;
 pub mod video;
 
 /// A planar direction.
-#[derive(Encode, Decode, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Direction {
     Left,
     Down,
@@ -70,7 +70,7 @@ pub enum Direction {
 }
 
 /// A planar axis.
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum Axis {
     Horizontal,
     Vertical,
@@ -129,7 +129,7 @@ pub fn toggle_default_workspace_capture() {
 }
 
 /// A workspace.
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Workspace(pub u64);
 
 impl Workspace {
@@ -170,7 +170,7 @@ pub fn get_workspace(name: &str) -> Workspace {
 /// PCI IDs can be used to identify a hardware component. See the Debian [documentation][pci].
 ///
 /// [pci]: https://wiki.debian.org/HowToIdentifyADevice/PCI
-#[derive(Encode, Decode, Debug, Copy, Clone, Hash, Eq, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, Eq, PartialEq, Default)]
 pub struct PciId {
     pub vendor: u32,
     pub model: u32,

--- a/jay-config/src/logging.rs
+++ b/jay-config/src/logging.rs
@@ -3,10 +3,10 @@
 //! Note that you can use the `log` crate for logging. All invocations of `log::info` etc.
 //! automatically log into the compositors log.
 
-use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 
 /// The log level of the compositor or a log message.
-#[derive(Encode, Decode, Copy, Clone, Debug)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub enum LogLevel {
     Error,
     Warn,

--- a/jay-config/src/theme.rs
+++ b/jay-config/src/theme.rs
@@ -1,6 +1,6 @@
 //! Tools for configuring the look of the compositor.
 
-use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 
 /// A color.
 ///
@@ -15,7 +15,7 @@ use bincode::{Decode, Encode};
 ///
 /// When using hexadecimal notation, `#RRGGBBAA`, the RGB values are usually straight.
 // values are stored premultiplied
-#[derive(Encode, Decode, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Color {
     r: f32,
     g: f32,
@@ -160,11 +160,11 @@ pub fn reset_font() {
 pub mod colors {
     use {
         crate::theme::Color,
-        bincode::{Decode, Encode},
+        serde::{Deserialize, Serialize},
     };
 
     /// An element of the GUI whose color can be changed.
-    #[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+    #[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
     pub struct Colorable(#[doc(hidden)] pub u32);
 
     impl Colorable {
@@ -262,10 +262,10 @@ pub mod colors {
 
 /// Elements of the compositor whose size can be changed.
 pub mod sized {
-    use bincode::{Decode, Encode};
+    use serde::{Deserialize, Serialize};
 
     /// An element of the GUI whose size can be changed.
-    #[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+    #[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
     pub struct Resizable(#[doc(hidden)] pub u32);
 
     impl Resizable {

--- a/jay-config/src/timer.rs
+++ b/jay-config/src/timer.rs
@@ -1,12 +1,12 @@
 //! Timers for one-time or repeated actions.
 
 use {
-    bincode::{Decode, Encode},
+    serde::{Deserialize, Serialize},
     std::time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 /// A timer.
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Timer(pub u64);
 
 /// Creates a new timer or returns an existing one.

--- a/jay-config/src/video.rs
+++ b/jay-config/src/video.rs
@@ -10,7 +10,7 @@ use {
         },
         PciId,
     },
-    bincode::{Decode, Encode},
+    serde::{Deserialize, Serialize},
     std::str::FromStr,
 };
 
@@ -59,7 +59,7 @@ impl Mode {
 ///
 /// A connector is the part that sticks out of your graphics card. A graphics card usually
 /// has many connectors but one few of them are actually connected to a monitor.
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Connector(pub u64);
 
 impl Connector {
@@ -286,10 +286,10 @@ impl ToConnectorId for &'_ str {
 
 /// Module containing all known connector types.
 pub mod connector_type {
-    use bincode::{Decode, Encode};
+    use serde::{Deserialize, Serialize};
 
     /// The type of a connector.
-    #[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+    #[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
     pub struct ConnectorType(pub u32);
 
     pub const CON_UNKNOWN: ConnectorType = ConnectorType(0);
@@ -321,7 +321,7 @@ pub mod connector_type {
 /// It's easiest to think of a DRM device as a graphics card.
 /// There are also DRM devices that are emulated in software but you are unlikely to encounter
 /// those accidentally.
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct DrmDevice(pub u64);
 
 impl DrmDevice {
@@ -373,7 +373,7 @@ impl DrmDevice {
 
 /// A graphics API.
 #[non_exhaustive]
-#[derive(Encode, Decode, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum GfxApi {
     OpenGl,
     Vulkan,

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use {
             unlink_on_drop::UnlinkOnDrop, xrd::xrd,
         },
     },
+    bincode::Options,
     jay_config::{
         _private::{
             bincode_ops,
@@ -175,8 +176,9 @@ impl ConfigProxy {
             timers_by_name: Default::default(),
             timers_by_id: Default::default(),
         });
-        let init_msg =
-            bincode::encode_to_vec(&InitMessage::V1(V1InitMessage {}), bincode_ops()).unwrap();
+        let init_msg = bincode_ops()
+            .serialize(&InitMessage::V1(V1InitMessage {}))
+            .unwrap();
         unsafe {
             let client_data = (entry.init)(
                 Rc::into_raw(data.clone()) as _,


### PR DESCRIPTION
This should not have any impact on existing configs since bincode claims compatibility of the wire format between 1.3.3 and 2.0.0.