### PR TITLE
wayland: make legacy wlr protocols privileged

### DIFF
--- a/src/ifs/zwlr_layer_shell_v1.rs
+++ b/src/ifs/zwlr_layer_shell_v1.rs
@@ -113,6 +113,10 @@ impl Global for ZwlrLayerShellV1Global {
     fn version(&self) -> u32 {
         4
     }
+
+    fn secure(&self) -> bool {
+        true
+    }
 }
 
 simple_add_global!(ZwlrLayerShellV1Global);

--- a/src/ifs/zwlr_screencopy_manager_v1.rs
+++ b/src/ifs/zwlr_screencopy_manager_v1.rs
@@ -59,6 +59,10 @@ impl Global for ZwlrScreencopyManagerV1Global {
     fn version(&self) -> u32 {
         3
     }
+
+    fn secure(&self) -> bool {
+        true
+    }
 }
 
 pub struct ZwlrScreencopyManagerV1 {


### PR DESCRIPTION
This will break applications that rely on default access to these protocols. E.g. mako, bemenu, grim, wallpaper engines, etc.
