### PR TITLE
wayland: implement wl_touch

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -133,7 +133,7 @@ Jay supports the following wayland protocols:
 | ext_session_lock_manager_v1             | 1                | Yes           |
 | ext_transient_seat_manager_v1           | 1[^ts_rejected]  | Yes           |
 | org_kde_kwin_server_decoration_manager  | 1                |               |
-| wl_compositor                           | 6[^no_touch]     |               |
+| wl_compositor                           | 6                |               |
 | wl_data_device_manager                  | 3                |               |
 | wl_drm                                  | 2                |               |
 | wl_output                               | 4                |               |
@@ -171,7 +171,6 @@ Jay supports the following wayland protocols:
 | zxdg_decoration_manager_v1              | 1                |               |
 | zxdg_output_manager_v1                  | 3                |               |
 
-[^no_touch]: Touch input is not supported.
 [^no_tearing]: Tearing screen updates are not supported.
 [^no_exclusive]: Exclusive zones are not supported.
 [^lsaccess]: Sandboxes can restrict access to this protocol.
@@ -182,5 +181,4 @@ Jay supports the following wayland protocols:
 The following features are currently not supported but might get implemented in the future:
 
 - Fine-grained damage tracking.
-- Touch support.
 - Tearing updates of fullscreen games.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -232,6 +232,23 @@ pub enum KeyState {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct TouchPosition {
+    pub x: Fixed,
+    pub y: Fixed,
+    pub x_transformed: Fixed,
+    pub y_transformed: Fixed,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum TouchEvent {
+    Down { pos: TouchPosition },
+    Up,
+    Motion { pos: TouchPosition },
+    Cancel,
+    Frame,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ScrollAxis {
     Horizontal = HORIZONTAL_SCROLL as _,
     Vertical = VERTICAL_SCROLL as _,
@@ -270,6 +287,12 @@ pub enum InputEvent {
         time_usec: u64,
         button: u32,
         state: KeyState,
+    },
+
+    Touch {
+        seat_slot: i32,
+        time_usec: u64,
+        event: TouchEvent,
     },
 
     AxisPx {

--- a/src/cli/seat_test.rs
+++ b/src/cli/seat_test.rs
@@ -15,7 +15,8 @@ use {
                 TabletPadStripSource, TabletPadStripStop, TabletToolButton, TabletToolDistance,
                 TabletToolDown, TabletToolFrame, TabletToolMotion, TabletToolPressure,
                 TabletToolProximityIn, TabletToolProximityOut, TabletToolRotation,
-                TabletToolSlider, TabletToolTilt, TabletToolUp, TabletToolWheel,
+                TabletToolSlider, TabletToolTilt, TabletToolUp, TabletToolWheel, TouchCancel,
+                TouchDown, TouchFrame, TouchMotion, TouchUp,
             },
         },
     },
@@ -582,6 +583,63 @@ async fn run(seat_test: Rc<SeatTest>) {
             print!(", stop");
         }
         println!();
+    });
+    let st = seat_test.clone();
+    TouchDown::handle(tc, se, (), move |_, ev| {
+        if all || ev.seat == seat {
+            if all {
+                print!("Seat: {}, ", st.name(ev.seat));
+            }
+            println!(
+                "Time: {:.4}, Touch: {}, Down: {}x{}",
+                time(ev.time_usec),
+                ev.id,
+                ev.x,
+                ev.y
+            );
+        }
+    });
+    let st = seat_test.clone();
+    TouchUp::handle(tc, se, (), move |_, ev| {
+        if all || ev.seat == seat {
+            if all {
+                print!("Seat: {}, ", st.name(ev.seat));
+            }
+            println!("Time: {:.4}, Touch: {}, Up", time(ev.time_usec), ev.id);
+        }
+    });
+    let st = seat_test.clone();
+    TouchMotion::handle(tc, se, (), move |_, ev| {
+        if all || ev.seat == seat {
+            if all {
+                print!("Seat: {}, ", st.name(ev.seat));
+            }
+            println!(
+                "Time: {:.4}, Touch: {} Motion: {}x{}",
+                time(ev.time_usec),
+                ev.id,
+                ev.x,
+                ev.y
+            );
+        }
+    });
+    let st = seat_test.clone();
+    TouchFrame::handle(tc, se, (), move |_, ev| {
+        if all || ev.seat == seat {
+            if all {
+                print!("Seat: {}, ", st.name(ev.seat));
+            }
+            println!("Time: {:.4}, Touch: {}, Frame", time(ev.time_usec), ev.id);
+        }
+    });
+    let st = seat_test.clone();
+    TouchCancel::handle(tc, se, (), move |_, ev| {
+        if all || ev.seat == seat {
+            if all {
+                print!("Seat: {}, ", st.name(ev.seat));
+            }
+            println!("Time: {:.4}, Touch: {}, Cancel", time(ev.time_usec), ev.id);
+        }
     });
     pending::<()>().await;
 }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -156,6 +156,7 @@ fn start_compositor2(
         connector_ids: Default::default(),
         root: Rc::new(DisplayNode::new(node_ids.next())),
         workspaces: Default::default(),
+        builtin_output: Default::default(),
         dummy_output: Default::default(),
         node_ids,
         backend_events: AsyncQueue::new(),

--- a/src/ifs/jay_seat_events.rs
+++ b/src/ifs/jay_seat_events.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        backend::{InputDeviceId, KeyState},
+        backend::{InputDeviceId, KeyState, TouchEvent},
         client::Client,
         fixed::Fixed,
         ifs::wl_seat::{
@@ -467,6 +467,55 @@ impl JaySeatEvents {
             input_device: pad.raw(),
             ring,
         });
+    }
+
+    pub fn send_touch(&self, seat: SeatId, time_usec: u64, id: i32, event: TouchEvent) {
+        match event {
+            TouchEvent::Down { pos } => {
+                self.client.event(TouchDown {
+                    self_id: self.id,
+                    seat: seat.raw(),
+                    time_usec,
+                    id,
+                    x: pos.x_transformed,
+                    y: pos.y_transformed,
+                });
+            }
+            TouchEvent::Up => {
+                self.client.event(TouchUp {
+                    self_id: self.id,
+                    seat: seat.raw(),
+                    time_usec,
+                    id,
+                });
+            }
+            TouchEvent::Motion { pos } => {
+                self.client.event(TouchMotion {
+                    self_id: self.id,
+                    seat: seat.raw(),
+                    time_usec,
+                    id,
+                    x: pos.x_transformed,
+                    y: pos.y_transformed,
+                });
+            }
+            TouchEvent::Frame => {
+                self.client.event(TouchFrame {
+                    self_id: self.id,
+                    seat: seat.raw(),
+                    time_usec,
+                    id,
+                });
+            }
+            TouchEvent::Cancel => {
+                self.client.event(TouchCancel {
+                    self_id: self.id,
+                    seat: seat.raw(),
+                    time_usec,
+                    id,
+                });
+            }
+        }
     }
 }
 

--- a/src/ifs/wl_seat/touch_owner.rs
+++ b/src/ifs/wl_seat/touch_owner.rs
@@ -1,0 +1,197 @@
+use {
+    crate::{
+        fixed::Fixed,
+        ifs::wl_seat::WlSeatGlobal,
+        rect::Rect,
+        tree::{FindTreeUsecase, FoundNode, Node},
+        utils::clonecell::CloneCell,
+    },
+    ahash::AHashSet,
+    std::{cell::RefCell, rc::Rc},
+};
+
+pub struct TouchOwnerHolder {
+    default: Rc<DefaultTouchOwner>,
+    owner: CloneCell<Rc<dyn TouchOwner>>,
+}
+
+impl Default for TouchOwnerHolder {
+    fn default() -> Self {
+        Self {
+            default: Rc::new(DefaultTouchOwner),
+            owner: CloneCell::new(Rc::new(DefaultTouchOwner)),
+        }
+    }
+}
+
+impl TouchOwnerHolder {
+    pub fn down(
+        &self,
+        seat: &Rc<WlSeatGlobal>,
+        mapped_node: Rc<dyn Node>,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        self.owner
+            .get()
+            .down(seat, mapped_node, time_usec, id, x, y)
+    }
+
+    pub fn up(&self, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32) {
+        self.owner.get().up(seat, time_usec, id)
+    }
+
+    pub fn motion(&self, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32, x: Fixed, y: Fixed) {
+        self.owner.get().motion(seat, time_usec, id, x, y)
+    }
+
+    pub fn frame(&self, seat: &Rc<WlSeatGlobal>) {
+        self.owner.get().frame(seat)
+    }
+
+    pub fn cancel(&self, seat: &Rc<WlSeatGlobal>) {
+        self.owner.get().cancel(seat)
+    }
+
+    pub fn clear(&self) {
+        self.owner.set(self.default.clone());
+    }
+}
+
+fn transform_abs(x: Fixed, y: Fixed, pos: Rect) -> (Fixed, Fixed) {
+    let x = Fixed::from_f64(x.to_f64() * f64::from(pos.width()));
+    let y = Fixed::from_f64(y.to_f64() * f64::from(pos.height()));
+    (x, y)
+}
+
+fn transform_rel(x: Fixed, y: Fixed, pos: Rect) -> (Fixed, Fixed) {
+    (x - pos.x1(), y - pos.y1())
+}
+
+struct DefaultTouchOwner;
+
+struct GrabTouchOwner {
+    pos: Rect,
+    node: Rc<dyn Node>,
+    down_ids: RefCell<AHashSet<i32>>,
+}
+
+trait TouchOwner {
+    fn down(
+        &self,
+        seat: &Rc<WlSeatGlobal>,
+        mapped_node: Rc<dyn Node>,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    );
+    fn up(&self, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32);
+    fn motion(&self, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32, x: Fixed, y: Fixed);
+    fn frame(&self, seat: &Rc<WlSeatGlobal>);
+    fn cancel(&self, seat: &Rc<WlSeatGlobal>);
+}
+
+impl TouchOwner for DefaultTouchOwner {
+    fn down(
+        &self,
+        seat: &Rc<WlSeatGlobal>,
+        mapped_node: Rc<dyn Node>,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        seat.cursor_group().deactivate();
+        let pos = mapped_node.node_absolute_position();
+        let (x, y) = transform_abs(x, y, pos);
+        let mut found_tree = seat.touch_found_tree.borrow_mut();
+        let x_int = x.round_down();
+        let y_int = y.round_down();
+        found_tree.push(FoundNode {
+            node: mapped_node.clone(),
+            x: x_int,
+            y: y_int,
+        });
+        mapped_node.node_find_tree_at(x_int, y_int, &mut found_tree, FindTreeUsecase::None);
+        if let Some(node) = found_tree.last() {
+            let node = node.node.clone();
+            node.node_seat_state().touch_begin(seat);
+            let down_ids = RefCell::new(AHashSet::new());
+            down_ids.borrow_mut().insert(id);
+            let (x_rel, y_rel) = transform_rel(x, y, node.node_absolute_position());
+            seat.touch_owner.owner.set(Rc::new(GrabTouchOwner {
+                pos,
+                node: node.clone(),
+                down_ids,
+            }));
+            node.node_on_touch_down(seat, time_usec, id, x_rel, y_rel);
+        }
+        found_tree.clear();
+    }
+
+    fn up(&self, _seat: &Rc<WlSeatGlobal>, _time_usec: u64, _id: i32) {
+        // nothing
+    }
+
+    fn motion(&self, _seat: &Rc<WlSeatGlobal>, _time_usec: u64, _id: i32, _x: Fixed, _y: Fixed) {
+        // nothing
+    }
+
+    fn frame(&self, _seat: &Rc<WlSeatGlobal>) {
+        // nothing
+    }
+
+    fn cancel(&self, _seat: &Rc<WlSeatGlobal>) {
+        // nothing
+    }
+}
+
+impl TouchOwner for GrabTouchOwner {
+    fn down(
+        &self,
+        seat: &Rc<WlSeatGlobal>,
+        _mapped_node: Rc<dyn Node>,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        self.down_ids.borrow_mut().insert(id);
+        let (x, y) = transform_abs(x, y, self.pos);
+        let (x_rel, y_rel) = transform_rel(x, y, self.node.node_absolute_position());
+        self.node
+            .clone()
+            .node_on_touch_down(seat, time_usec, id, x_rel, y_rel);
+    }
+
+    fn up(&self, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32) {
+        self.down_ids.borrow_mut().remove(&id);
+        self.node.clone().node_on_touch_up(seat, time_usec, id);
+        if self.down_ids.borrow().is_empty() {
+            self.node.node_seat_state().touch_end(seat);
+            seat.touch_owner.clear();
+        }
+    }
+
+    fn motion(&self, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32, x: Fixed, y: Fixed) {
+        self.down_ids.borrow_mut().insert(id);
+        let (x, y) = transform_abs(x, y, self.pos);
+        let (x_rel, y_rel) = transform_rel(x, y, self.node.node_absolute_position());
+        self.node
+            .clone()
+            .node_on_touch_motion(seat, time_usec, id, x_rel, y_rel);
+    }
+
+    fn frame(&self, seat: &Rc<WlSeatGlobal>) {
+        self.node.node_on_touch_frame(seat);
+    }
+
+    fn cancel(&self, seat: &Rc<WlSeatGlobal>) {
+        self.node.node_on_touch_cancel(seat);
+        self.node.node_seat_state().touch_end(seat);
+        seat.touch_owner.clear();
+    }
+}

--- a/src/ifs/wl_seat/wl_touch.rs
+++ b/src/ifs/wl_seat/wl_touch.rs
@@ -1,29 +1,20 @@
 use {
     crate::{
         client::ClientError,
+        fixed::Fixed,
         ifs::wl_seat::WlSeat,
         leaks::Tracker,
-        object::Object,
-        wire::{wl_touch::*, WlTouchId},
+        object::{Object, Version},
+        wire::{wl_touch::*, WlSurfaceId, WlTouchId},
     },
     std::rc::Rc,
     thiserror::Error,
 };
 
 #[allow(dead_code)]
-const DOWN: u32 = 0;
+pub const SHAPE_SINCE_VERSION: Version = Version(6);
 #[allow(dead_code)]
-const UP: u32 = 1;
-#[allow(dead_code)]
-const MOTION: u32 = 2;
-#[allow(dead_code)]
-const FRAME: u32 = 3;
-#[allow(dead_code)]
-const CANCEL: u32 = 4;
-#[allow(dead_code)]
-const SHAPE: u32 = 5;
-#[allow(dead_code)]
-const ORIENTATION: u32 = 6;
+pub const ORIENTATION_DIRECTION_SINCE_VERSION: Version = Version(6);
 
 pub struct WlTouch {
     id: WlTouchId,
@@ -39,12 +30,79 @@ impl WlTouch {
             tracker: Default::default(),
         }
     }
+
+    pub fn send_down(
+        &self,
+        serial: u32,
+        time: u32,
+        surface: WlSurfaceId,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        self.seat.client.event(Down {
+            self_id: self.id,
+            serial,
+            time,
+            surface,
+            id,
+            x,
+            y,
+        })
+    }
+
+    pub fn send_up(&self, serial: u32, time: u32, id: i32) {
+        self.seat.client.event(Up {
+            self_id: self.id,
+            serial,
+            time,
+            id,
+        })
+    }
+
+    pub fn send_motion(&self, time: u32, id: i32, x: Fixed, y: Fixed) {
+        self.seat.client.event(Motion {
+            self_id: self.id,
+            time,
+            id,
+            x,
+            y,
+        })
+    }
+
+    pub fn send_frame(&self) {
+        self.seat.client.event(Frame { self_id: self.id })
+    }
+
+    pub fn send_cancel(&self) {
+        self.seat.client.event(Cancel { self_id: self.id })
+    }
+
+    #[allow(dead_code)]
+    pub fn send_shape(&self, id: i32, major: Fixed, minor: Fixed) {
+        self.seat.client.event(Shape {
+            self_id: self.id,
+            id,
+            major,
+            minor,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn send_orientation(&self, id: i32, orientation: Fixed) {
+        self.seat.client.event(Orientation {
+            self_id: self.id,
+            id,
+            orientation,
+        })
+    }
 }
 
 impl WlTouchRequestHandler for WlTouch {
     type Error = WlTouchError;
 
     fn release(&self, _req: Release, _slf: &Rc<Self>) -> Result<(), Self::Error> {
+        self.seat.touches.remove(&self.id);
         self.seat.client.remove_obj(self)?;
         Ok(())
     }

--- a/src/ifs/wl_surface.rs
+++ b/src/ifs/wl_surface.rs
@@ -1436,6 +1436,40 @@ impl Node for WlSurface {
         seat.mods_surface(self, kb_state);
     }
 
+    fn node_on_touch_down(
+        self: Rc<Self>,
+        seat: &Rc<WlSeatGlobal>,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        seat.touch_down_surface(&self, time_usec, id, x, y)
+    }
+
+    fn node_on_touch_up(self: Rc<Self>, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32) {
+        seat.touch_up_surface(&self, time_usec, id)
+    }
+
+    fn node_on_touch_motion(
+        self: Rc<Self>,
+        seat: &WlSeatGlobal,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        seat.touch_motion_surface(&self, time_usec, id, x, y)
+    }
+
+    fn node_on_touch_frame(&self, seat: &WlSeatGlobal) {
+        seat.touch_frame(&self)
+    }
+
+    fn node_on_touch_cancel(&self, seat: &WlSeatGlobal) {
+        seat.touch_cancel(&self)
+    }
+
     fn node_on_button(
         self: Rc<Self>,
         seat: &Rc<WlSeatGlobal>,

--- a/src/libinput/event.rs
+++ b/src/libinput/event.rs
@@ -16,17 +16,17 @@ use {
             libinput_event_get_gesture_event, libinput_event_get_keyboard_event,
             libinput_event_get_pointer_event, libinput_event_get_switch_event,
             libinput_event_get_tablet_pad_event, libinput_event_get_tablet_tool_event,
-            libinput_event_get_type, libinput_event_keyboard, libinput_event_keyboard_get_key,
-            libinput_event_keyboard_get_key_state, libinput_event_keyboard_get_time_usec,
-            libinput_event_pointer, libinput_event_pointer_get_button,
-            libinput_event_pointer_get_button_state, libinput_event_pointer_get_dx,
-            libinput_event_pointer_get_dx_unaccelerated, libinput_event_pointer_get_dy,
-            libinput_event_pointer_get_dy_unaccelerated, libinput_event_pointer_get_scroll_value,
-            libinput_event_pointer_get_scroll_value_v120, libinput_event_pointer_get_time_usec,
-            libinput_event_pointer_has_axis, libinput_event_switch,
-            libinput_event_switch_get_switch, libinput_event_switch_get_switch_state,
-            libinput_event_switch_get_time_usec, libinput_event_tablet_pad,
-            libinput_event_tablet_pad_get_button_number,
+            libinput_event_get_touch_event, libinput_event_get_type, libinput_event_keyboard,
+            libinput_event_keyboard_get_key, libinput_event_keyboard_get_key_state,
+            libinput_event_keyboard_get_time_usec, libinput_event_pointer,
+            libinput_event_pointer_get_button, libinput_event_pointer_get_button_state,
+            libinput_event_pointer_get_dx, libinput_event_pointer_get_dx_unaccelerated,
+            libinput_event_pointer_get_dy, libinput_event_pointer_get_dy_unaccelerated,
+            libinput_event_pointer_get_scroll_value, libinput_event_pointer_get_scroll_value_v120,
+            libinput_event_pointer_get_time_usec, libinput_event_pointer_has_axis,
+            libinput_event_switch, libinput_event_switch_get_switch,
+            libinput_event_switch_get_switch_state, libinput_event_switch_get_time_usec,
+            libinput_event_tablet_pad, libinput_event_tablet_pad_get_button_number,
             libinput_event_tablet_pad_get_button_state, libinput_event_tablet_pad_get_mode,
             libinput_event_tablet_pad_get_mode_group, libinput_event_tablet_pad_get_ring_number,
             libinput_event_tablet_pad_get_ring_position, libinput_event_tablet_pad_get_ring_source,
@@ -40,10 +40,13 @@ use {
             libinput_event_tablet_tool_get_tool,
             libinput_event_tablet_tool_get_wheel_delta_discrete,
             libinput_event_tablet_tool_get_x_transformed,
-            libinput_event_tablet_tool_get_y_transformed, libinput_tablet_tool,
-            libinput_tablet_tool_get_serial, libinput_tablet_tool_get_tool_id,
-            libinput_tablet_tool_get_type, libinput_tablet_tool_get_user_data,
-            libinput_tablet_tool_set_user_data,
+            libinput_event_tablet_tool_get_y_transformed, libinput_event_touch,
+            libinput_event_touch_get_seat_slot, libinput_event_touch_get_time_usec,
+            libinput_event_touch_get_x, libinput_event_touch_get_x_transformed,
+            libinput_event_touch_get_y, libinput_event_touch_get_y_transformed,
+            libinput_tablet_tool, libinput_tablet_tool_get_serial,
+            libinput_tablet_tool_get_tool_id, libinput_tablet_tool_get_type,
+            libinput_tablet_tool_get_user_data, libinput_tablet_tool_set_user_data,
         },
     },
     std::marker::PhantomData,
@@ -86,6 +89,11 @@ pub struct LibInputEventTabletPad<'a> {
 
 pub struct LibInputTabletTool<'a> {
     pub(super) tool: *mut libinput_tablet_tool,
+    pub(super) _phantom: PhantomData<&'a ()>,
+}
+
+pub struct LibInputEventTouch<'a> {
+    pub(super) event: *mut libinput_event_touch,
     pub(super) _phantom: PhantomData<&'a ()>,
 }
 
@@ -154,6 +162,11 @@ impl<'a> LibInputEvent<'a> {
         tablet_pad_event,
         LibInputEventTabletPad,
         libinput_event_get_tablet_pad_event
+    );
+    converter!(
+        touch_event,
+        LibInputEventTouch,
+        libinput_event_get_touch_event
     );
 }
 
@@ -465,5 +478,30 @@ impl<'a> LibInputEventTabletPad<'a> {
             group: unsafe { libinput_event_tablet_pad_get_mode_group(self.event) },
             _phantom: Default::default(),
         }
+    }
+}
+
+impl<'a> LibInputEventTouch<'a> {
+    pub fn seat_slot(&self) -> i32 {
+        unsafe { libinput_event_touch_get_seat_slot(self.event) }
+    }
+    pub fn x(&self) -> f64 {
+        unsafe { libinput_event_touch_get_x(self.event) }
+    }
+
+    pub fn y(&self) -> f64 {
+        unsafe { libinput_event_touch_get_y(self.event) }
+    }
+
+    pub fn x_transformed(&self, width: u32) -> f64 {
+        unsafe { libinput_event_touch_get_x_transformed(self.event, width) }
+    }
+
+    pub fn y_transformed(&self, height: u32) -> f64 {
+        unsafe { libinput_event_touch_get_y_transformed(self.event, height) }
+    }
+
+    pub fn time_usec(&self) -> u64 {
+        unsafe { libinput_event_touch_get_time_usec(self.event) }
     }
 }

--- a/src/libinput/sys.rs
+++ b/src/libinput/sys.rs
@@ -30,6 +30,8 @@ pub struct libinput_tablet_pad_mode_group(u8);
 pub struct libinput_tablet_tool(u8);
 // #[repr(transparent)]
 // pub struct libinput_tablet_pad(u8);
+#[repr(transparent)]
+pub struct libinput_event_touch(u8);
 
 #[link(name = "input")]
 extern "C" {
@@ -357,6 +359,20 @@ extern "C" {
     //     group: *mut libinput_tablet_pad_mode_group,
     //     button: c::c_uint,
     // ) -> c::c_int;
+
+    pub fn libinput_event_get_touch_event(event: *mut libinput_event) -> *mut libinput_event_touch;
+    pub fn libinput_event_touch_get_seat_slot(event: *mut libinput_event_touch) -> i32;
+    pub fn libinput_event_touch_get_time_usec(event: *mut libinput_event_touch) -> u64;
+    pub fn libinput_event_touch_get_x(event: *mut libinput_event_touch) -> f64;
+    pub fn libinput_event_touch_get_x_transformed(
+        event: *mut libinput_event_touch,
+        width: u32,
+    ) -> f64;
+    pub fn libinput_event_touch_get_y(event: *mut libinput_event_touch) -> f64;
+    pub fn libinput_event_touch_get_y_transformed(
+        event: *mut libinput_event_touch,
+        height: u32,
+    ) -> f64;
 }
 
 #[repr(C)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -130,6 +130,7 @@ pub struct State {
     pub node_ids: NodeIds,
     pub root: Rc<DisplayNode>,
     pub workspaces: CopyHashMap<String, Rc<WorkspaceNode>>,
+    pub builtin_output: Cell<Option<ConnectorId>>,
     pub dummy_output: CloneCell<Option<Rc<OutputNode>>>,
     pub backend_events: AsyncQueue<BackendEvent>,
     pub input_device_handlers: RefCell<AHashMap<InputDeviceId, InputDeviceData>>,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -200,6 +200,50 @@ pub trait Node: 'static {
         let _ = kb_state;
     }
 
+    fn node_on_touch_down(
+        self: Rc<Self>,
+        seat: &Rc<WlSeatGlobal>,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        let _ = seat;
+        let _ = time_usec;
+        let _ = id;
+        let _ = x;
+        let _ = y;
+    }
+
+    fn node_on_touch_up(self: Rc<Self>, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32) {
+        let _ = seat;
+        let _ = time_usec;
+        let _ = id;
+    }
+
+    fn node_on_touch_motion(
+        self: Rc<Self>,
+        seat: &WlSeatGlobal,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        let _ = seat;
+        let _ = time_usec;
+        let _ = id;
+        let _ = x;
+        let _ = y;
+    }
+
+    fn node_on_touch_frame(&self, seat: &WlSeatGlobal) {
+        let _ = seat;
+    }
+
+    fn node_on_touch_cancel(&self, seat: &WlSeatGlobal) {
+        let _ = seat;
+    }
+
     fn node_on_button(
         self: Rc<Self>,
         seat: &Rc<WlSeatGlobal>,

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -148,6 +148,7 @@ pub struct ContainerChild {
 enum CursorType {
     Seat(SeatId),
     TabletTool(TabletToolId),
+    Touch(i32),
 }
 
 struct CursorState {
@@ -1273,6 +1274,34 @@ impl Node for ContainerNode {
 
     fn node_toplevel(self: Rc<Self>) -> Option<Rc<dyn crate::tree::ToplevelNode>> {
         Some(self)
+    }
+
+    fn node_on_touch_down(
+        self: Rc<Self>,
+        seat: &Rc<WlSeatGlobal>,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        let id = CursorType::Touch(id);
+        self.pointer_move(id, seat.pointer_cursor(), x, y, false);
+        self.button(id, seat, time_usec, true);
+    }
+
+    fn node_on_touch_up(self: Rc<Self>, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32) {
+        self.button(CursorType::Touch(id), seat, time_usec, false);
+    }
+
+    fn node_on_touch_motion(
+        self: Rc<Self>,
+        seat: &WlSeatGlobal,
+        _time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        self.pointer_move(CursorType::Touch(id), seat.pointer_cursor(), x, y, false);
     }
 
     fn node_on_button(

--- a/src/tree/float.rs
+++ b/src/tree/float.rs
@@ -56,6 +56,7 @@ pub struct FloatNode {
 enum CursorType {
     Seat(SeatId),
     TabletTool(TabletToolId),
+    Touch(i32),
 }
 
 struct CursorState {
@@ -565,6 +566,41 @@ impl Node for FloatNode {
 
     fn node_render(&self, renderer: &mut Renderer, x: i32, y: i32, _bounds: Option<&Rect>) {
         renderer.render_floating(self, x, y)
+    }
+
+    fn node_on_touch_down(
+        self: Rc<Self>,
+        seat: &Rc<WlSeatGlobal>,
+        time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        let id = CursorType::Touch(id);
+        let cursor = seat.pointer_cursor();
+        self.pointer_move(id, cursor, x, y, false);
+        self.button(id, cursor, seat, time_usec, true);
+    }
+
+    fn node_on_touch_up(self: Rc<Self>, seat: &Rc<WlSeatGlobal>, time_usec: u64, id: i32) {
+        self.button(
+            CursorType::Touch(id),
+            seat.pointer_cursor(),
+            seat,
+            time_usec,
+            false,
+        );
+    }
+
+    fn node_on_touch_motion(
+        self: Rc<Self>,
+        seat: &WlSeatGlobal,
+        _time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        self.pointer_move(CursorType::Touch(id), seat.pointer_cursor(), x, y, false);
     }
 
     fn node_on_button(

--- a/src/tree/output.rs
+++ b/src/tree/output.rs
@@ -78,6 +78,7 @@ pub struct OutputNode {
 pub enum PointerType {
     Seat(SeatId),
     TabletTool(TabletToolId),
+    Touch(i32),
 }
 
 pub async fn output_render_data(state: Rc<State>) {
@@ -863,6 +864,30 @@ impl Node for OutputNode {
 
     fn node_render(&self, renderer: &mut Renderer, x: i32, y: i32, _bounds: Option<&Rect>) {
         renderer.render_output(self, x, y);
+    }
+
+    fn node_on_touch_down(
+        self: Rc<Self>,
+        _seat: &Rc<WlSeatGlobal>,
+        _time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        let id = PointerType::Touch(id);
+        self.pointer_move(id, x, y);
+        self.button(id);
+    }
+
+    fn node_on_touch_motion(
+        self: Rc<Self>,
+        _seat: &WlSeatGlobal,
+        _time_usec: u64,
+        id: i32,
+        x: Fixed,
+        y: Fixed,
+    ) {
+        self.pointer_move(PointerType::Touch(id), x, y);
     }
 
     fn node_on_button(

--- a/src/video/drm.rs
+++ b/src/video/drm.rs
@@ -910,7 +910,7 @@ impl Drop for Change {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ConnectorType {
     Unknown(u32),
     VGA,

--- a/wire/jay_seat_events.txt
+++ b/wire/jay_seat_events.txt
@@ -239,3 +239,37 @@ event tablet_pad_ring_frame {
     input_device: u32,
     ring: u32,
 }
+
+event touch_down {
+    seat: u32,
+    time_usec: pod(u64),
+    id: i32,
+    x: fixed,
+    y: fixed,
+}
+
+event touch_up {
+    seat: u32,
+    time_usec: pod(u64),
+    id: i32,
+}
+
+event touch_motion {
+    seat: u32,
+    time_usec: pod(u64),
+    id: i32,
+    x: fixed,
+    y: fixed,
+}
+
+event touch_frame {
+    seat: u32,
+    time_usec: pod(u64),
+    id: i32,
+}
+
+event touch_cancel {
+    seat: u32,
+    time_usec: pod(u64),
+    id: i32,
+}

--- a/wire/wl_touch.txt
+++ b/wire/wl_touch.txt
@@ -23,7 +23,7 @@ event up {
 
 event motion {
     time: u32,
-    id: u32,
+    id: i32,
     x: fixed,
     y: fixed,
 }


### PR DESCRIPTION
I'm testing this on a touchscreen laptop and trying to implement basic support:

- [x] Send events to the active client at the correct position (tested by tapping, scrolling and zooming in Konsole and Firefox)
- [x] Hide the cursor on touch down
- [x] Switch the active client on touch down
- [x] Switch client on titlebar touch down
- [x] Switch workspace on bar touch down
- [x] Resize clients with touch motion on the edges/corners

Future work:
- calibration-matrix option for switching the orientation of a touchscreen
- touch gestures/bindings

Closes #115