### PR TITLE
all: clear more reference cycles at shutdown

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -24,6 +24,9 @@ linear_ids!(DrmDeviceIds, DrmDeviceId);
 
 pub trait Backend {
     fn run(self: Rc<Self>) -> SpawnedFuture<Result<(), Box<dyn Error>>>;
+    fn clear(&self) {
+        // nothing
+    }
     #[cfg_attr(not(feature = "it"), allow(dead_code))]
     fn into_any(self: Rc<Self>) -> Rc<dyn Any>;
 

--- a/src/backends/metal/video.rs
+++ b/src/backends/metal/video.rs
@@ -323,12 +323,12 @@ impl ConnectorDisplayData {
 linear_ids!(MetalLeaseIds, MetalLeaseId, u64);
 
 pub struct MetalLeaseData {
-    lease: DrmLease,
-    _lessee: Rc<dyn BackendDrmLessee>,
-    connectors: Vec<Rc<MetalConnector>>,
-    crtcs: Vec<Rc<MetalCrtc>>,
-    planes: Vec<Rc<MetalPlane>>,
-    revoked: Cell<bool>,
+    pub lease: DrmLease,
+    pub _lessee: Rc<dyn BackendDrmLessee>,
+    pub connectors: Vec<Rc<MetalConnector>>,
+    pub crtcs: Vec<Rc<MetalCrtc>>,
+    pub planes: Vec<Rc<MetalPlane>>,
+    pub revoked: Cell<bool>,
 }
 
 impl MetalLeaseData {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,8 @@
     clippy::uninlined_format_args,
     clippy::manual_is_ascii_check,
     clippy::needless_borrow,
-    clippy::unnecessary_cast
+    clippy::unnecessary_cast,
+    clippy::manual_flatten
 )]
 
 #[macro_use]

--- a/src/state.rs
+++ b/src/state.rs
@@ -722,7 +722,7 @@ impl State {
             forker.clear();
         }
         self.acceptor.set(None);
-        self.backend.set(Rc::new(DummyBackend));
+        self.backend.set(Rc::new(DummyBackend)).clear();
         self.run_toplevel.clear();
         self.xwayland.handler.borrow_mut().take();
         self.xwayland.queue.clear();
@@ -730,6 +730,7 @@ impl State {
         self.idle.change.clear();
         for (_, drm_dev) in self.drm_devs.lock().drain() {
             drm_dev.handler.take();
+            drm_dev.connectors.clear();
         }
         for (_, connector) in self.connectors.lock().drain() {
             connector.handler.take();

--- a/src/utils/on_change.rs
+++ b/src/utils/on_change.rs
@@ -12,6 +12,11 @@ pub struct OnChange<T> {
 }
 
 impl<T> OnChange<T> {
+    pub fn clear(&self) {
+        self.on_change.take();
+        self.events.take();
+    }
+
     pub fn send_event(&self, event: T) {
         self.events.push(event);
         if let Some(cb) = self.on_change.get() {

--- a/src/xwayland/xwm.rs
+++ b/src/xwayland/xwm.rs
@@ -264,7 +264,15 @@ impl Drop for Wm {
             if let Some(window) = window.window.take() {
                 window.break_loops();
             }
+            window.children.clear();
+            window.parent.take();
+            window.stack_link.take();
+            window.map_link.take();
         }
+        self.windows_by_surface_id.clear();
+        self.windows_by_surface_serial.clear();
+        self.focus_window.take();
+        self.known_seats.clear();
     }
 }
 


### PR DESCRIPTION
This does not fix any serious issues since it's only about memory that is leaked at shutdown. But otherwise it is not possible to find actual leaks.