### PR TITLE
wayland: send drop event unconditionally on drop

### DIFF
--- a/src/ifs/wl_seat/pointer_owner.rs
+++ b/src/ifs/wl_seat/pointer_owner.rs
@@ -464,6 +464,8 @@ impl PointerOwner for DndPointerOwner {
         if button != self.button || state != KeyState::Released {
             return;
         }
+        let target = self.target.get();
+        target.node_on_dnd_drop(&self.dnd);
         if let Some(src) = &self.dnd.src {
             src.on_drop(seat);
         }
@@ -471,9 +473,7 @@ impl PointerOwner for DndPointerOwner {
             None => true,
             Some(s) => s.can_drop(),
         };
-        let target = self.target.get();
         if should_drop {
-            self.target.get().node_on_dnd_drop(&self.dnd);
             *seat.dropped_dnd.borrow_mut() = Some(DroppedDnd {
                 dnd: self.dnd.clone(),
             });


### PR DESCRIPTION
The chromium DnD code has been fucked for a long time and starting in 126 the whole tab freezes if a drop is started and ended within the same tabe. This commit fixes this issue and it seems to also not break any other applications.