### PR TITLE
pointer movement during focus changes

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -447,6 +447,10 @@ impl Client {
         self.send(&ClientMessage::DisablePointerConstraint { seat });
     }
 
+    pub fn center_pointer_on_focused(&self, seat: Seat) {
+        self.send(&ClientMessage::CenterPointerOnFocused { seat });
+    }
+
     pub fn move_to_output(&self, workspace: WorkspaceSource, connector: Connector) {
         self.send(&ClientMessage::MoveToOutput {
             workspace,

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -429,8 +429,12 @@ impl Client {
         capture
     }
 
-    pub fn show_workspace(&self, seat: Seat, workspace: Workspace) {
-        self.send(&ClientMessage::ShowWorkspace { seat, workspace });
+    pub fn show_workspace(&self, seat: Seat, workspace: Workspace, move_pointer: bool) {
+        self.send(&ClientMessage::ShowWorkspace {
+            seat,
+            workspace,
+            move_pointer,
+        });
     }
 
     pub fn set_workspace(&self, seat: Seat, workspace: Workspace) {

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -341,6 +341,9 @@ pub enum ClientMessage<'a> {
     DisablePointerConstraint {
         seat: Seat,
     },
+    CenterPointerOnFocused {
+        seat: Seat,
+    },
     ConnectorSetEnabled {
         connector: Connector,
         enabled: bool,

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -256,6 +256,7 @@ pub enum ClientMessage<'a> {
     ShowWorkspace {
         seat: Seat,
         workspace: Workspace,
+        move_pointer: bool,
     },
     SetWorkspace {
         seat: Seat,

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -356,8 +356,8 @@ impl Seat {
     ///
     /// If the workspace doesn't currently exist, it is created on the output that contains the
     /// seat's cursor.
-    pub fn show_workspace(self, workspace: Workspace) {
-        get!().show_workspace(self, workspace)
+    pub fn show_workspace(self, workspace: Workspace, move_pointer: bool) {
+        get!().show_workspace(self, workspace, move_pointer)
     }
 
     /// Moves the currently focused window to the workspace.

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -385,6 +385,11 @@ impl Seat {
         get!().disable_pointer_constraint(self)
     }
 
+    /// Centers the mouse pointer on the focused window.
+    pub fn center_pointer_on_focused(self) {
+        get!().center_pointer_on_focused(self)
+    }
+
     /// Moves the currently focused workspace to another output.
     pub fn move_to_output(self, connector: Connector) {
         get!().move_to_output(WorkspaceSource::Seat(self), connector);

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -993,6 +993,12 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
+    fn handle_center_pointer_on_focused(&self, seat: Seat) -> Result<(), CphError> {
+        let seat = self.get_seat(seat)?;
+        seat.center_pointer_on_focused();
+        Ok(())
+    }
+
     fn handle_set_use_hardware_cursor(
         &self,
         seat: Seat,
@@ -1695,6 +1701,9 @@ impl ConfigProxyHandler {
             ClientMessage::DisablePointerConstraint { seat } => self
                 .handle_disable_pointer_constraint(seat)
                 .wrn("disable_pointer_constraint")?,
+            ClientMessage::CenterPointerOnFocused { seat } => self
+                .handle_center_pointer_on_focused(seat)
+                .wrn("center_pointer_on_focused")?,
             ClientMessage::MakeRenderDevice { device } => self
                 .handle_make_render_device(device)
                 .wrn("make_render_device")?,

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -784,10 +784,15 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
-    fn handle_show_workspace(&self, seat: Seat, ws: Workspace) -> Result<(), CphError> {
+    fn handle_show_workspace(
+        &self,
+        seat: Seat,
+        ws: Workspace,
+        move_pointer: bool,
+    ) -> Result<(), CphError> {
         let seat = self.get_seat(seat)?;
         let name = self.get_workspace(ws)?;
-        self.state.show_workspace(&seat, &name);
+        self.state.show_workspace(&seat, &name, move_pointer);
         Ok(())
     }
 
@@ -1598,8 +1603,12 @@ impl ConfigProxyHandler {
                 self.handle_get_device_name(device).wrn("get_device_name")?
             }
             ClientMessage::GetWorkspace { name } => self.handle_get_workspace(name),
-            ClientMessage::ShowWorkspace { seat, workspace } => self
-                .handle_show_workspace(seat, workspace)
+            ClientMessage::ShowWorkspace {
+                seat,
+                workspace,
+                move_pointer,
+            } => self
+                .handle_show_workspace(seat, workspace, move_pointer)
                 .wrn("show_workspace")?,
             ClientMessage::SetWorkspace { seat, workspace } => self
                 .handle_set_workspace(seat, workspace)

--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -405,6 +405,12 @@ impl WlSeatGlobal {
         }
     }
 
+    pub fn center_pointer_on_focused(&self) {
+        let kb_node = self.keyboard_node.get();
+        let (x, y) = kb_node.node_absolute_position().center();
+        self.pointer_cursor.set_position(Fixed(x), Fixed(y));
+    }
+
     fn maybe_constrain_pointer_node(&self) {
         if let Some(pn) = self.pointer_node() {
             if let Some(surface) = pn.node_into_surface() {

--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -407,8 +407,13 @@ impl WlSeatGlobal {
 
     pub fn center_pointer_on_focused(&self) {
         let kb_node = self.keyboard_node.get();
-        let (x, y) = kb_node.node_absolute_position().center();
-        self.pointer_cursor.set_position(Fixed(x), Fixed(y));
+        if let Some(tl) = kb_node.node_toplevel() {
+            let (x, y) = tl.node_absolute_position().center();
+            println!("xy {x} {y}");
+            println!("fi {} {}", Fixed::from_int(x), Fixed::from_int(y));
+            self.pointer_cursor
+                .set_position(Fixed::from_int(x), Fixed::from_int(y));
+        }
     }
 
     fn maybe_constrain_pointer_node(&self) {

--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -409,8 +409,6 @@ impl WlSeatGlobal {
         let kb_node = self.keyboard_node.get();
         if let Some(tl) = kb_node.node_toplevel() {
             let (x, y) = tl.node_absolute_position().center();
-            println!("xy {x} {y}");
-            println!("fi {} {}", Fixed::from_int(x), Fixed::from_int(y));
             self.pointer_cursor
                 .set_position(Fixed::from_int(x), Fixed::from_int(y));
         }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -237,4 +237,11 @@ impl Rect {
     pub fn size(&self) -> (i32, i32) {
         (self.width(), self.height())
     }
+
+    pub fn center(&self) -> (i32, i32) {
+        (
+            self.raw.x1 + self.width() / 2,
+            self.raw.y1 + self.height() / 2,
+        )
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -634,12 +634,18 @@ impl State {
         }
     }
 
-    pub fn show_workspace(&self, seat: &Rc<WlSeatGlobal>, name: &str) {
+    pub fn show_workspace(&self, seat: &Rc<WlSeatGlobal>, name: &str, move_pointer: bool) {
         let (output, ws) = match self.workspaces.get(name) {
             Some(ws) => {
                 let output = ws.output.get();
                 let did_change = output.show_workspace(&ws);
                 ws.clone().node_do_focus(seat, Direction::Unspecified);
+                if move_pointer {
+                    let pc = seat.pointer_cursor();
+                    pc.activate();
+                    let (x, y) = ws.node_absolute_position().center();
+                    pc.set_position(Fixed::from_int(x), Fixed::from_int(y));
+                }
                 if !did_change {
                     return;
                 }

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -107,6 +107,7 @@ pub enum Action {
     },
     ShowWorkspace {
         name: String,
+        move_pointer: bool,
     },
     SimpleCommand {
         cmd: SimpleCommand,

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -38,6 +38,7 @@ use {
 pub enum SimpleCommand {
     Close,
     DisablePointerConstraint,
+    CenterPointerOnFocused,
     Focus(Direction),
     FocusParent,
     Move(Direction),

--- a/toml-config/src/config/parsers/action.rs
+++ b/toml-config/src/config/parsers/action.rs
@@ -104,6 +104,7 @@ impl ActionParser<'_> {
             "focus-parent" => FocusParent,
             "close" => Close,
             "disable-pointer-constraint" => DisablePointerConstraint,
+            "center-pointer-on-focused" => CenterPointerOnFocused,
             "toggle-floating" => ToggleFloating,
             "quit" => Quit,
             "reload-config-toml" => ReloadConfigToml,

--- a/toml-config/src/config/parsers/action.rs
+++ b/toml-config/src/config/parsers/action.rs
@@ -144,7 +144,11 @@ impl ActionParser<'_> {
 
     fn parse_show_workspace(&mut self, ext: &mut Extractor<'_>) -> ParseResult<Self> {
         let name = ext.extract(str("name"))?.value.to_string();
-        Ok(Action::ShowWorkspace { name })
+        let move_pointer = match ext.extract(opt(bol("move-pointer")))? {
+            None => false,
+            Some(v) => v.value,
+        };
+        Ok(Action::ShowWorkspace { name, move_pointer })
     }
 
     fn parse_move_to_workspace(&mut self, ext: &mut Extractor<'_>) -> ParseResult<Self> {

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -106,9 +106,9 @@ impl Action {
             }
             Action::Exec { exec } => B::new(move || create_command(&exec).spawn()),
             Action::SwitchToVt { num } => B::new(move || switch_to_vt(num)),
-            Action::ShowWorkspace { name } => {
+            Action::ShowWorkspace { name, move_pointer } => {
                 let workspace = get_workspace(&name);
-                B::new(move || s.show_workspace(workspace))
+                B::new(move || s.show_workspace(workspace, move_pointer))
             }
             Action::MoveToWorkspace { name } => {
                 let workspace = get_workspace(&name);

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -80,6 +80,9 @@ impl Action {
                 SimpleCommand::DisablePointerConstraint => {
                     B::new(move || s.disable_pointer_constraint())
                 }
+                SimpleCommand::CenterPointerOnFocused => {
+                    B::new(move || s.center_pointer_on_focused())
+                }
                 SimpleCommand::ToggleFloating => B::new(move || s.toggle_floating()),
                 SimpleCommand::Quit => B::new(quit),
                 SimpleCommand::ReloadConfigToml => {

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -204,6 +204,13 @@ Action:
               description: The name of the workspace.
               required: true
               kind: string
+            move-pointer:
+              description: |
+               Whether to move the pointer to the workspace.
+               
+               If this is omitted, the pointer is not moved.
+              required: false
+              kind: bool
         move-to-workspace:
           description: |
             Moves the currently focused window to a workspace.


### PR DESCRIPTION
These commits make two changes: the addition of the command `"center-pointer-on-focused"` and the addition of the option `move-pointer` (bool) to the `"show-workspace"` command type.

This was needed for my two-monitor setup. In my practice, it looks like this in the config:

```toml
# example
# alt-space = "center-pointer-on-focused"

alt-h = ["focus-left", "center-pointer-on-focused"]
alt-j = ["focus-down", "center-pointer-on-focused"]
alt-k = ["focus-up", "center-pointer-on-focused"]
alt-l = ["focus-right", "center-pointer-on-focused"]
```
and
```toml
alt-1 = { type = "show-workspace", name = "1", move-pointer = true }
alt-2 = { type = "show-workspace", name = "2", move-pointer = true }
alt-3 = { type = "show-workspace", name = "3", move-pointer = true }
alt-4 = { type = "show-workspace", name = "4", move-pointer = true }
alt-5 = { type = "show-workspace", name = "5", move-pointer = true }
alt-6 = { type = "show-workspace", name = "6", move-pointer = true }
alt-7 = { type = "show-workspace", name = "7", move-pointer = true }
alt-8 = { type = "show-workspace", name = "8", move-pointer = true }
alt-9 = { type = "show-workspace", name = "9", move-pointer = true }
alt-0 = { type = "show-workspace", name = "10", move-pointer = true }
```

A known issue is that pairing `"center-pointer-on-focused"` with a command such as `"move-left"`, the cursor actually snaps to the wrong location. Perhaps a bug in move (tl rect not updated?) but I didn't look into it yet. Another issue is that when alacritty hides the cursor during typing (a feature that I like!), the activation that was necessary in order to move cross-monitor can sometimes prevent that behavior from resuming - but it will after toggling fullscreen, so perhaps activating the cursor before the cursor jump (if invisible), then deactivating it again to the previous state will be necessary.

Additional work I intend to do is allowing the `"focus-*"` commands to move between outputs/monitors. But I wanted to submit the PR for review in case I'm doing this all wrong. While it's working for me locally already, there may be other issues. If you get a chance to look at it, I'm interested in your thoughts.

One contribution question I had - I wasn't sure about updating `spec.yaml`. I did so for the option, but not the new command. Should that be completed also?

Edit: Looks like the test for `"show-workspace"` will need to be updated too.