### PR TITLE
Fix toplevel screencasts with hardware cursors

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -494,6 +494,7 @@ fn create_dummy_output(state: &Rc<State>) {
         screencopies: Default::default(),
         title_visible: Cell::new(false),
         schedule,
+        latch_event: Default::default(),
     });
     let dummy_workspace = Rc::new(WorkspaceNode {
         id: state.node_ids.next(),

--- a/src/ifs/jay_compositor.rs
+++ b/src/ifs/jay_compositor.rs
@@ -325,7 +325,7 @@ impl JayCompositorRequestHandler for JayCompositor {
     }
 
     fn create_screencast(&self, req: CreateScreencast, _slf: &Rc<Self>) -> Result<(), Self::Error> {
-        let sc = Rc::new(JayScreencast::new(req.id, &self.client));
+        let sc = Rc::new_cyclic(|slf| JayScreencast::new(req.id, &self.client, slf));
         track!(self.client, sc);
         self.client.add_client_obj(&sc)?;
         Ok(())

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -360,11 +360,6 @@ impl Renderer<'_> {
         bounds: Option<&Rect>,
         render_highlight: bool,
     ) {
-        if self.result.is_some() {
-            for screencast in tl_data.jay_screencasts.lock().values() {
-                screencast.schedule_toplevel_screencast();
-            }
-        }
         if render_highlight {
             self.render_highlight(tl_data, bounds);
         }

--- a/src/tasks/connector.rs
+++ b/src/tasks/connector.rs
@@ -185,6 +185,7 @@ impl ConnectorHandler {
             screencopies: Default::default(),
             title_visible: Default::default(),
             schedule,
+            latch_event: Default::default(),
         });
         on.update_visible();
         on.update_rects();

--- a/src/tree/output.rs
+++ b/src/tree/output.rs
@@ -436,7 +436,9 @@ impl OutputNode {
 
     pub fn ensure_workspace(self: &Rc<Self>) -> Rc<WorkspaceNode> {
         if let Some(ws) = self.workspace.get() {
-            return ws;
+            if !ws.is_dummy {
+                return ws;
+            }
         }
         let name = 'name: {
             for i in 1.. {

--- a/src/tree/output.rs
+++ b/src/tree/output.rs
@@ -37,8 +37,8 @@ use {
         },
         utils::{
             clonecell::CloneCell, copyhashmap::CopyHashMap, errorfmt::ErrorFmt,
-            hash_map_ext::HashMapExt, linkedlist::LinkedList, scroller::Scroller,
-            transform_ext::TransformExt,
+            event_listener::EventSource, hash_map_ext::HashMapExt, linkedlist::LinkedList,
+            scroller::Scroller, transform_ext::TransformExt,
         },
         wire::{JayOutputId, JayScreencastId, ZwlrScreencopyFrameV1Id},
     },
@@ -80,6 +80,11 @@ pub struct OutputNode {
     pub screencopies: CopyHashMap<(ClientId, ZwlrScreencopyFrameV1Id), Rc<ZwlrScreencopyFrameV1>>,
     pub title_visible: Cell<bool>,
     pub schedule: Rc<OutputSchedule>,
+    pub latch_event: EventSource<dyn LatchListener>,
+}
+
+pub trait LatchListener {
+    fn after_latch(self: Rc<Self>);
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -148,6 +153,9 @@ impl OutputNode {
         y_off: i32,
         size: Option<(i32, i32)>,
     ) {
+        for listener in self.latch_event.iter() {
+            listener.after_latch();
+        }
         if let Some(workspace) = self.workspace.get() {
             if !workspace.may_capture.get() {
                 return;

--- a/src/tree/workspace.rs
+++ b/src/tree/workspace.rs
@@ -7,7 +7,9 @@ use {
             jay_workspace::JayWorkspace,
             wl_output::OutputId,
             wl_seat::{tablet::TabletTool, NodeSeatState, WlSeatGlobal},
-            wl_surface::WlSurface,
+            wl_surface::{
+                x_surface::xwindow::Xwindow, xdg_surface::xdg_toplevel::XdgToplevel, WlSurface,
+            },
         },
         rect::Rect,
         renderer::Renderer,
@@ -16,7 +18,7 @@ use {
         tree::{
             container::ContainerNode, walker::NodeVisitor, ContainingNode, Direction,
             FindTreeResult, FindTreeUsecase, FoundNode, Node, NodeId, NodeVisitorBase, OutputNode,
-            StackedNode, ToplevelNode,
+            PlaceholderNode, StackedNode, ToplevelNode,
         },
         utils::{
             clonecell::CloneCell,
@@ -101,6 +103,26 @@ impl WorkspaceNode {
         impl NodeVisitorBase for OutputSetter<'_> {
             fn visit_surface(&mut self, node: &Rc<WlSurface>) {
                 node.set_output(self.0);
+            }
+
+            fn visit_container(&mut self, node: &Rc<ContainerNode>) {
+                node.tl_workspace_output_changed();
+                node.node_visit_children(self);
+            }
+
+            fn visit_toplevel(&mut self, node: &Rc<XdgToplevel>) {
+                node.tl_workspace_output_changed();
+                node.node_visit_children(self);
+            }
+
+            fn visit_xwindow(&mut self, node: &Rc<Xwindow>) {
+                node.tl_workspace_output_changed();
+                node.node_visit_children(self);
+            }
+
+            fn visit_placeholder(&mut self, node: &Rc<PlaceholderNode>) {
+                node.tl_workspace_output_changed();
+                node.node_visit_children(self);
             }
         }
         let mut visitor = OutputSetter(output);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,6 +14,7 @@ pub mod copyhashmap;
 pub mod debug_fn;
 pub mod double_click_state;
 pub mod errorfmt;
+pub mod event_listener;
 pub mod fdcloser;
 pub mod gfx_api_ext;
 pub mod hash_map_ext;

--- a/src/utils/event_listener.rs
+++ b/src/utils/event_listener.rs
@@ -1,0 +1,69 @@
+use {
+    crate::utils::linkedlist::{LinkedList, LinkedListIter, LinkedNode},
+    std::{
+        cell::Cell,
+        rc::{Rc, Weak},
+    },
+};
+
+pub struct EventSource<T: ?Sized> {
+    listeners: LinkedList<Weak<T>>,
+    on_attach: Cell<Option<Box<dyn FnOnce()>>>,
+}
+
+pub struct EventListener<T: ?Sized> {
+    link: LinkedNode<Weak<T>>,
+}
+
+impl<T: ?Sized> Default for EventSource<T> {
+    fn default() -> Self {
+        Self {
+            listeners: Default::default(),
+            on_attach: Default::default(),
+        }
+    }
+}
+
+impl<T: ?Sized> EventSource<T> {
+    pub fn iter(&self) -> EventSourceIter<T> {
+        EventSourceIter {
+            iter: self.listeners.iter(),
+        }
+    }
+}
+
+pub struct EventSourceIter<T: ?Sized> {
+    iter: LinkedListIter<Weak<T>>,
+}
+
+impl<T: ?Sized> Iterator for EventSourceIter<T> {
+    type Item = Rc<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for weak in self.iter.by_ref() {
+            if let Some(t) = weak.upgrade() {
+                return Some(t);
+            }
+        }
+        None
+    }
+}
+
+impl<T: ?Sized> EventListener<T> {
+    pub fn new(t: Weak<T>) -> Self {
+        Self {
+            link: LinkedNode::detached(t),
+        }
+    }
+
+    pub fn attach(&self, source: &EventSource<T>) {
+        source.listeners.add_last_existing(&self.link);
+        if let Some(on_attach) = source.on_attach.take() {
+            on_attach();
+        }
+    }
+
+    pub fn detach(&self) {
+        self.link.detach();
+    }
+}


### PR DESCRIPTION
Partially fixes #235. If the toplevel crosses multiple outputs, then cursor movements on the non-primary output do not cause the toplevel to be captured.

This is good enough for the next release.