### PR TITLE
io_uring: fix cq mapping

### DIFF
--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -129,7 +129,7 @@ impl IoUring {
         };
         let cqmap_map = mmap(
             params.cq_off.cqes as usize
-                + params.sq_entries as usize * mem::size_of::<io_uring_cqe>(),
+                + params.cq_entries as usize * mem::size_of::<io_uring_cqe>(),
             c::PROT_READ | c::PROT_WRITE,
             c::MAP_SHARED | c::MAP_POPULATE,
             fd.raw(),


### PR DESCRIPTION
Closes #259 

I fixed this bug a long time ago but for some reason never pushed it and eventually it was lost.