### PR TITLE
Implement passive cursor damage to fix cursor refresh rate

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -155,6 +155,7 @@ pub trait HardwareCursorUpdate {
 
 pub trait HardwareCursor: Debug {
     fn damage(&self);
+    fn passive_damage(&self);
 }
 
 pub type TransformMatrix = [[f64; 2]; 2];

--- a/src/output_schedule.rs
+++ b/src/output_schedule.rs
@@ -126,6 +126,10 @@ impl OutputSchedule {
     }
 
     pub fn hardware_cursor_changed(&self) {
+        if let Some(hc) = self.hardware_cursor.get() {
+            hc.passive_damage();
+        }
+
         if !self.needs_hardware_cursor_commit.replace(true) {
             self.trigger();
         }


### PR DESCRIPTION
Jay currently allows to specify a minimum cursor refresh rate. When running with VRR above this refresh rate the cursor completely stops moving which is probably not the intended behavior (tested with vrrtest). 

This patch implements a passive update mode which allows to notify the backend about the cursor position having changed without causing a flip therefore deferring the cursor plane update to the next time the damage call is made to the backend.