### PR TITLE
wl_surface: don't flip when there is no damage

### DIFF
--- a/src/ifs/wl_surface.rs
+++ b/src/ifs/wl_surface.rs
@@ -1372,11 +1372,6 @@ impl WlSurface {
                 if has_frame_requests {
                     output.global.connector.damage();
                 }
-            } else if has_frame_requests && output.schedule.vrr_enabled() {
-                // Frame requests must be dispatched at the highest possible frame rate.
-                // Therefore we must trigger a vsync of the output as soon as possible.
-                let rect = output.global.pos.get();
-                self.client.state.damage(rect);
             }
         } else {
             if fifo_barrier_set {


### PR DESCRIPTION
This patch removes a piece of code that will cause a kms flip unnecessarily.

I'm not sure what the original intention of this code was, however what it results in is commits that don't come from mesa WSI to be intepreted as frame submissions from the application.

This introduces flips with spurious timing which break VRR. The exact symptom in many games is that the display goes out of sync when moving the mouse (cursor not visible, not sure why exactly moving the mouse causes the game to commit).

Removing the code fixes this.