### PR TITLE
Fixed cargo command from documentation

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -42,7 +42,7 @@ This will install Jay under `$HOME/.cargo/bin/jay`.
 If you want to use the latest version from git, run
 
 ```
-cargo install --locked --git https://github.com/mahkoh/jay.git jay
+cargo install --locked --git https://github.com/mahkoh/jay.git jay-compositor
 ```
 
 If you only want to build Jay without installing it, run the following command from within this repository:


### PR DESCRIPTION
If I execute
`cargo install --locked --git https://github.com/mahkoh/jay.git jay`
I get the error: `error: could not find `jay` in https://github.com/mahkoh/jay.git with version '*'`

The change `jay` to `jay-compositor` fixes it

PD: my first commit on any project ever, I didn't knew that you need to fork the entire project to just fix a "spelling error" lol. Good luck with the project manhkoh (your name sound's like a "slur" on latinamerican videogame communities lul)