### PR TITLE
tree: focus float nodes when switching workspaces

### DIFF
--- a/src/it/tests.rs
+++ b/src/it/tests.rs
@@ -75,6 +75,7 @@ mod t0040_virtual_keyboard;
 mod t0041_input_method;
 mod t0042_toplevel_select;
 mod t0043_destroy_registry;
+mod t0044_stacked_focus;
 
 pub trait TestCase: Sync {
     fn name(&self) -> &'static str;
@@ -137,5 +138,6 @@ pub fn tests() -> Vec<&'static dyn TestCase> {
         t0041_input_method,
         t0042_toplevel_select,
         t0043_destroy_registry,
+        t0044_stacked_focus,
     }
 }

--- a/src/it/tests/t0044_stacked_focus.rs
+++ b/src/it/tests/t0044_stacked_focus.rs
@@ -1,0 +1,40 @@
+use {
+    crate::{
+        it::{test_error::TestError, testrun::TestRun},
+        tree::ToplevelNodeBase,
+    },
+    std::rc::Rc,
+};
+
+testcase!();
+
+/// Test that container focus is set to a lone stacked window when switching to its workspace
+async fn test(run: Rc<TestRun>) -> Result<(), TestError> {
+    let ds = run.create_default_setup().await?;
+    let client = run.create_client().await?;
+
+    run.cfg.show_workspace(ds.seat.id(), "1")?;
+    let win1 = client.create_window().await?;
+    win1.map().await?;
+    client.sync().await;
+    run.cfg.set_floating(ds.seat.id(), true)?;
+
+    run.cfg.show_workspace(ds.seat.id(), "2")?;
+    let win2 = client.create_window().await?;
+    win2.map().await?;
+    client.sync().await;
+
+    run.cfg.show_workspace(ds.seat.id(), "1")?;
+
+    let container = match win1.tl.server.tl_data().parent.get() {
+        Some(p) => match p.node_into_float() {
+            Some(p) => p,
+            _ => bail!("Containing node is not a float"),
+        },
+        _ => bail!("Toplevel doesn't have a parent"),
+    };
+
+    tassert!(container.active.get());
+
+    Ok(())
+}

--- a/src/tree/workspace.rs
+++ b/src/tree/workspace.rs
@@ -276,6 +276,14 @@ impl Node for WorkspaceNode {
             fs.tl_into_node().node_do_focus(seat, direction);
         } else if let Some(container) = self.container.get() {
             container.node_do_focus(seat, direction);
+        } else if let Some(float) = self
+            .stacked
+            .rev_iter()
+            .find_map(|node| (*node).clone().node_into_float())
+        {
+            if let Some(child) = float.child.get() {
+                child.node_do_focus(seat, direction);
+            }
         }
     }
 


### PR DESCRIPTION
Right now if a workspace only contains a floating node, switching to that workspace will not change the currently focused window (without focus-follows-mouse doing its thing)

