### PR TITLE
xdg-toplevel: apply fullscreen state after mapping tiled window

### DIFF
--- a/src/ifs/wl_surface/x_surface/xwindow.rs
+++ b/src/ifs/wl_surface/x_surface/xwindow.rs
@@ -282,6 +282,9 @@ impl Xwindow {
             }
             Change::Map => {
                 self.data.state.map_tiled(self.clone());
+                if self.data.info.fullscreen.get() {
+                    self.clone().tl_set_fullscreen(true);
+                }
                 self.data.title_changed();
             }
         }

--- a/src/ifs/wl_surface/xdg_surface/xdg_toplevel.rs
+++ b/src/ifs/wl_surface/xdg_surface/xdg_toplevel.rs
@@ -376,6 +376,13 @@ impl XdgToplevel {
 
     fn map_tiled(self: &Rc<Self>) {
         self.state.map_tiled(self.clone());
+        let fullscreen = self.states.borrow().contains(&STATE_FULLSCREEN);
+        if fullscreen {
+            if let Some(ws) = self.xdg.workspace.get() {
+                self.toplevel_data
+                    .set_fullscreen2(&self.state, self.clone(), &ws);
+            }
+        }
     }
 
     pub fn prepare_toplevel_drag(&self) {


### PR DESCRIPTION
Fixes #385 