### PR TITLE
ei: Fix flipped scroll axes

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -280,7 +280,7 @@ pub enum KeyState {
     Pressed,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Linearize)]
 pub enum ScrollAxis {
     Horizontal = HORIZONTAL_SCROLL as _,
     Vertical = VERTICAL_SCROLL as _,

--- a/src/cli/seat_test.rs
+++ b/src/cli/seat_test.rs
@@ -190,14 +190,14 @@ async fn run(seat_test: Rc<SeatTest>) {
     let st = seat_test.clone();
     AxisFrame::handle(tc, se, ps.clone(), move |ps, ev| {
         let source = ps.source.take();
-        let px_x = ps.px[HORIZONTAL_SCROLL as usize].take();
-        let px_y = ps.px[VERTICAL_SCROLL as usize].take();
-        let stop_x = ps.stop[HORIZONTAL_SCROLL as usize].take();
-        let stop_y = ps.stop[VERTICAL_SCROLL as usize].take();
-        let v120_x = ps.v120[HORIZONTAL_SCROLL as usize].take();
-        let v120_y = ps.v120[VERTICAL_SCROLL as usize].take();
-        let inverted_x = ps.inverted[HORIZONTAL_SCROLL as usize].get();
-        let inverted_y = ps.inverted[VERTICAL_SCROLL as usize].get();
+        let px_x = ps.px[HORIZONTAL_SCROLL].take();
+        let px_y = ps.px[VERTICAL_SCROLL].take();
+        let stop_x = ps.stop[HORIZONTAL_SCROLL].take();
+        let stop_y = ps.stop[VERTICAL_SCROLL].take();
+        let v120_x = ps.v120[HORIZONTAL_SCROLL].take();
+        let v120_y = ps.v120[VERTICAL_SCROLL].take();
+        let inverted_x = ps.inverted[HORIZONTAL_SCROLL].get();
+        let inverted_y = ps.inverted[VERTICAL_SCROLL].get();
         if all || ev.seat == seat {
             if all {
                 print!("Seat: {}, ", st.name(ev.seat));

--- a/src/cli/seat_test.rs
+++ b/src/cli/seat_test.rs
@@ -2,7 +2,9 @@ use {
     crate::{
         cli::{GlobalArgs, SeatTestArgs},
         fixed::Fixed,
-        ifs::wl_seat::wl_pointer::{CONTINUOUS, FINGER, PendingScroll, WHEEL},
+        ifs::wl_seat::wl_pointer::{
+            CONTINUOUS, FINGER, HORIZONTAL_SCROLL, PendingScroll, VERTICAL_SCROLL, WHEEL,
+        },
         tools::tool_client::{Handle, ToolClient, with_tool_client},
         wire::{
             jay_compositor::{GetSeats, Seat, SeatEvents},
@@ -188,14 +190,14 @@ async fn run(seat_test: Rc<SeatTest>) {
     let st = seat_test.clone();
     AxisFrame::handle(tc, se, ps.clone(), move |ps, ev| {
         let source = ps.source.take();
-        let px_x = ps.px[0].take();
-        let px_y = ps.px[1].take();
-        let stop_x = ps.stop[0].take();
-        let stop_y = ps.stop[1].take();
-        let v120_x = ps.v120[0].take();
-        let v120_y = ps.v120[1].take();
-        let inverted_x = ps.inverted[0].get();
-        let inverted_y = ps.inverted[1].get();
+        let px_x = ps.px[HORIZONTAL_SCROLL as usize].take();
+        let px_y = ps.px[VERTICAL_SCROLL as usize].take();
+        let stop_x = ps.stop[HORIZONTAL_SCROLL as usize].take();
+        let stop_y = ps.stop[VERTICAL_SCROLL as usize].take();
+        let v120_x = ps.v120[HORIZONTAL_SCROLL as usize].take();
+        let v120_y = ps.v120[VERTICAL_SCROLL as usize].take();
+        let inverted_x = ps.inverted[HORIZONTAL_SCROLL as usize].get();
+        let inverted_y = ps.inverted[VERTICAL_SCROLL as usize].get();
         if all || ev.seat == seat {
             if all {
                 print!("Seat: {}, ", st.name(ev.seat));

--- a/src/ei/ei_ifs/ei_device.rs
+++ b/src/ei/ei_ifs/ei_device.rs
@@ -21,6 +21,7 @@ use {
             },
         },
     },
+    linearize::LinearizeExt,
     std::{cell::Cell, rc::Rc},
     thiserror::Error,
 };
@@ -204,7 +205,7 @@ impl EiDeviceRequestHandler for EiDevice {
         }
         {
             let mut need_frame = false;
-            for axis in [ScrollAxis::Horizontal, ScrollAxis::Vertical] {
+            for axis in ScrollAxis::variants() {
                 let idx = axis as usize;
                 if let Some(v120) = self.scroll_v120[idx].take() {
                     need_frame = true;

--- a/src/ei/ei_ifs/ei_scroll.rs
+++ b/src/ei/ei_ifs/ei_scroll.rs
@@ -6,6 +6,7 @@ use {
             ei_object::{EiObject, EiVersion},
         },
         fixed::Fixed,
+        ifs::wl_seat::wl_pointer::{HORIZONTAL_SCROLL, VERTICAL_SCROLL},
         leaks::Tracker,
         wire_ei::{
             EiScrollId,
@@ -65,8 +66,8 @@ impl EiScrollRequestHandler for EiScroll {
     }
 
     fn client_scroll(&self, req: ClientScroll, _slf: &Rc<Self>) -> Result<(), Self::Error> {
-        self.device.scroll_px[0].set(Some(req.x));
-        self.device.scroll_px[1].set(Some(req.y));
+        self.device.scroll_px[HORIZONTAL_SCROLL as usize].set(Some(req.x));
+        self.device.scroll_px[VERTICAL_SCROLL as usize].set(Some(req.y));
         Ok(())
     }
 
@@ -75,8 +76,8 @@ impl EiScrollRequestHandler for EiScroll {
         req: ClientScrollDiscrete,
         _slf: &Rc<Self>,
     ) -> Result<(), Self::Error> {
-        self.device.scroll_v120[0].set(Some(req.x));
-        self.device.scroll_v120[1].set(Some(req.y));
+        self.device.scroll_v120[HORIZONTAL_SCROLL as usize].set(Some(req.x));
+        self.device.scroll_v120[VERTICAL_SCROLL as usize].set(Some(req.y));
         Ok(())
     }
 
@@ -85,8 +86,8 @@ impl EiScrollRequestHandler for EiScroll {
         req: ClientScrollStop,
         _slf: &Rc<Self>,
     ) -> Result<(), Self::Error> {
-        self.device.scroll_stop[0].set(Some(req.x != 0));
-        self.device.scroll_stop[1].set(Some(req.y != 0));
+        self.device.scroll_stop[HORIZONTAL_SCROLL as usize].set(Some(req.x != 0));
+        self.device.scroll_stop[VERTICAL_SCROLL as usize].set(Some(req.y != 0));
         Ok(())
     }
 }

--- a/src/ei/ei_ifs/ei_scroll.rs
+++ b/src/ei/ei_ifs/ei_scroll.rs
@@ -66,8 +66,8 @@ impl EiScrollRequestHandler for EiScroll {
     }
 
     fn client_scroll(&self, req: ClientScroll, _slf: &Rc<Self>) -> Result<(), Self::Error> {
-        self.device.scroll_px[HORIZONTAL_SCROLL as usize].set(Some(req.x));
-        self.device.scroll_px[VERTICAL_SCROLL as usize].set(Some(req.y));
+        self.device.scroll_px[HORIZONTAL_SCROLL].set(Some(req.x));
+        self.device.scroll_px[VERTICAL_SCROLL].set(Some(req.y));
         Ok(())
     }
 
@@ -76,8 +76,8 @@ impl EiScrollRequestHandler for EiScroll {
         req: ClientScrollDiscrete,
         _slf: &Rc<Self>,
     ) -> Result<(), Self::Error> {
-        self.device.scroll_v120[HORIZONTAL_SCROLL as usize].set(Some(req.x));
-        self.device.scroll_v120[VERTICAL_SCROLL as usize].set(Some(req.y));
+        self.device.scroll_v120[HORIZONTAL_SCROLL].set(Some(req.x));
+        self.device.scroll_v120[VERTICAL_SCROLL].set(Some(req.y));
         Ok(())
     }
 
@@ -86,8 +86,8 @@ impl EiScrollRequestHandler for EiScroll {
         req: ClientScrollStop,
         _slf: &Rc<Self>,
     ) -> Result<(), Self::Error> {
-        self.device.scroll_stop[HORIZONTAL_SCROLL as usize].set(Some(req.x != 0));
-        self.device.scroll_stop[VERTICAL_SCROLL as usize].set(Some(req.y != 0));
+        self.device.scroll_stop[HORIZONTAL_SCROLL].set(Some(req.x != 0));
+        self.device.scroll_stop[VERTICAL_SCROLL].set(Some(req.y != 0));
         Ok(())
     }
 }

--- a/src/ei/ei_ifs/ei_seat.rs
+++ b/src/ei/ei_ifs/ei_seat.rs
@@ -166,18 +166,16 @@ impl EiSeat {
         }
         if let Some(b) = self.scroll.get() {
             b.send_scroll(
-                ps.px[HORIZONTAL_SCROLL as usize].get().unwrap_or_default(),
-                ps.px[VERTICAL_SCROLL as usize].get().unwrap_or_default(),
+                ps.px[HORIZONTAL_SCROLL].get().unwrap_or_default(),
+                ps.px[VERTICAL_SCROLL].get().unwrap_or_default(),
             );
             b.send_scroll_discrete(
-                ps.v120[HORIZONTAL_SCROLL as usize]
-                    .get()
-                    .unwrap_or_default(),
-                ps.v120[VERTICAL_SCROLL as usize].get().unwrap_or_default(),
+                ps.v120[HORIZONTAL_SCROLL].get().unwrap_or_default(),
+                ps.v120[VERTICAL_SCROLL].get().unwrap_or_default(),
             );
             b.send_scroll_stop(
-                ps.stop[HORIZONTAL_SCROLL as usize].get(),
-                ps.stop[VERTICAL_SCROLL as usize].get(),
+                ps.stop[HORIZONTAL_SCROLL].get(),
+                ps.stop[VERTICAL_SCROLL].get(),
             );
             b.device.send_frame(self.client.serial(), time_usec);
         }

--- a/src/ei/ei_ifs/ei_seat.rs
+++ b/src/ei/ei_ifs/ei_seat.rs
@@ -16,7 +16,10 @@ use {
             ei_object::{EiInterface, EiObject, EiVersion},
         },
         fixed::Fixed,
-        ifs::wl_seat::{PhysicalKeyboardId, WlSeatGlobal, wl_pointer::PendingScroll},
+        ifs::wl_seat::{
+            PhysicalKeyboardId, WlSeatGlobal,
+            wl_pointer::{HORIZONTAL_SCROLL, PendingScroll, VERTICAL_SCROLL},
+        },
         keyboard::{DynKeyboardState, KeyboardState, KeyboardStateId},
         leaks::Tracker,
         tree::Node,
@@ -163,14 +166,19 @@ impl EiSeat {
         }
         if let Some(b) = self.scroll.get() {
             b.send_scroll(
-                ps.px[0].get().unwrap_or_default(),
-                ps.px[1].get().unwrap_or_default(),
+                ps.px[HORIZONTAL_SCROLL as usize].get().unwrap_or_default(),
+                ps.px[VERTICAL_SCROLL as usize].get().unwrap_or_default(),
             );
             b.send_scroll_discrete(
-                ps.v120[0].get().unwrap_or_default(),
-                ps.v120[1].get().unwrap_or_default(),
+                ps.v120[HORIZONTAL_SCROLL as usize]
+                    .get()
+                    .unwrap_or_default(),
+                ps.v120[VERTICAL_SCROLL as usize].get().unwrap_or_default(),
             );
-            b.send_scroll_stop(ps.stop[0].get(), ps.stop[1].get());
+            b.send_scroll_stop(
+                ps.stop[HORIZONTAL_SCROLL as usize].get(),
+                ps.stop[VERTICAL_SCROLL as usize].get(),
+            );
             b.device.send_frame(self.client.serial(), time_usec);
         }
     }

--- a/src/ifs/jay_seat_events.rs
+++ b/src/ifs/jay_seat_events.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        backend::{InputDeviceId, KeyState},
+        backend::{InputDeviceId, KeyState, ScrollAxis},
         client::Client,
         fixed::Fixed,
         ifs::wl_seat::{
@@ -15,6 +15,7 @@ use {
         object::{Object, Version},
         wire::{JaySeatEventsId, jay_seat_events::*},
     },
+    linearize::LinearizeExt,
     std::{convert::Infallible, rc::Rc},
 };
 
@@ -95,7 +96,8 @@ impl JaySeatEvents {
                 source,
             });
         }
-        for axis in 0..1 {
+        for axis in ScrollAxis::variants() {
+            let axis = axis as usize;
             if let Some(dist) = ps.v120[axis].get() {
                 self.client.event(Axis120 {
                     self_id: self.id,

--- a/src/ifs/wl_seat/event_handling.rs
+++ b/src/ifs/wl_seat/event_handling.rs
@@ -54,6 +54,7 @@ use {
         },
     },
     kbvm::{ModifierMask, state_machine::Event},
+    linearize::LinearizeExt,
     smallvec::SmallVec,
     std::{cell::RefCell, collections::hash_map::Entry, mem, rc::Rc},
 };
@@ -1173,7 +1174,8 @@ impl WlSeatGlobal {
         }
         let time = (event.time_usec.get() / 1000) as _;
         self.for_each_pointer(Version::ALL, surface.client.id, |p| {
-            for i in 0..1 {
+            for i in ScrollAxis::variants() {
+                let i = i as usize;
                 let axis = i as _;
                 if let Some(delta) = event.v120[i].get() {
                     if p.seat.version >= AXIS_VALUE120_SINCE_VERSION {

--- a/src/ifs/wl_seat/pointer_owner.rs
+++ b/src/ifs/wl_seat/pointer_owner.rs
@@ -21,6 +21,7 @@ use {
         },
         utils::{clonecell::CloneCell, smallmap::SmallMap},
     },
+    linearize::LinearizeExt,
     std::{
         cell::Cell,
         rc::{Rc, Weak},
@@ -80,7 +81,8 @@ impl PointerOwnerHolder {
     pub fn frame(&self, px_per_scroll_wheel: f64, seat: &Rc<WlSeatGlobal>, time_usec: u64) {
         self.pending_scroll.time_usec.set(time_usec);
         let pending = self.pending_scroll.take();
-        for axis in 0..2 {
+        for axis in ScrollAxis::variants() {
+            let axis = axis as usize;
             if let Some(dist) = pending.v120[axis].get() {
                 let px = (dist as f64 / AXIS_120 as f64) * px_per_scroll_wheel;
                 pending.px[axis].set(Some(Fixed::from_f64(px)));

--- a/src/ifs/wl_seat/wl_pointer.rs
+++ b/src/ifs/wl_seat/wl_pointer.rs
@@ -18,8 +18,8 @@ const ROLE: u32 = 0;
 pub(super) const RELEASED: u32 = 0;
 pub const PRESSED: u32 = 1;
 
-pub const VERTICAL_SCROLL: u32 = 0;
-pub const HORIZONTAL_SCROLL: u32 = 1;
+pub const VERTICAL_SCROLL: usize = 0;
+pub const HORIZONTAL_SCROLL: usize = 1;
 
 pub const WHEEL: u32 = 0;
 pub const FINGER: u32 = 1;

--- a/src/utils/scroller.rs
+++ b/src/utils/scroller.rs
@@ -17,14 +17,14 @@ pub struct Scroller {
 
 impl Scroller {
     pub fn handle(&self, scroll: &PendingScroll) -> Option<i32> {
-        let n = if let Some(d) = scroll.v120[VERTICAL_SCROLL as usize].get() {
+        let n = if let Some(d) = scroll.v120[VERTICAL_SCROLL].get() {
             self.px.set(0.0);
             let mut v120 = self.v120.get() + d;
             let discrete = v120 / AXIS_120;
             v120 -= discrete * AXIS_120;
             self.v120.set(v120);
             discrete
-        } else if let Some(px) = scroll.px[VERTICAL_SCROLL as usize].get() {
+        } else if let Some(px) = scroll.px[VERTICAL_SCROLL].get() {
             self.v120.set(0);
             let mut px = self.px.get() + px.to_f64();
             let discrete = (px / PX_PER_SCROLL).trunc();
@@ -34,7 +34,7 @@ impl Scroller {
         } else {
             0
         };
-        if scroll.stop[VERTICAL_SCROLL as usize].get() {
+        if scroll.stop[VERTICAL_SCROLL].get() {
             self.v120.set(0);
             self.px.set(0.0);
         }


### PR DESCRIPTION
This allows for emulating ordinary vertical scrolling with libei. I think horizontal scrolling might be broken due to [this](https://github.com/mahkoh/jay/blob/efd9e38c28a0f902947858277b3b026fd3d2e44f/src/ifs/jay_seat_events.rs#L98) but I haven't looked into that yet.