### PR TITLE
wl_drm: hide global if invalid modifier is not supported

### DIFF
--- a/src/gfx_api.rs
+++ b/src/gfx_api.rs
@@ -795,6 +795,10 @@ pub trait GfxContext: Debug {
     fn supports_color_management(&self) -> bool {
         false
     }
+
+    fn supports_invalid_modifier(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/gfx_apis/gl/renderer/context.rs
+++ b/src/gfx_apis/gl/renderer/context.rs
@@ -347,4 +347,8 @@ impl GfxContext for GlRenderContext {
     ) -> Result<Rc<dyn GfxBlendBuffer>, GfxError> {
         Err(GfxError(Box::new(RenderError::NoBlendBuffer)))
     }
+
+    fn supports_invalid_modifier(&self) -> bool {
+        true
+    }
 }

--- a/src/ifs/wl_drm.rs
+++ b/src/ifs/wl_drm.rs
@@ -6,6 +6,7 @@ use {
         ifs::wl_buffer::WlBuffer,
         leaks::Tracker,
         object::{Object, Version},
+        state::State,
         video::{
             INVALID_MODIFIER,
             dmabuf::{DmaBuf, DmaBufPlane, PlaneVec},
@@ -61,6 +62,13 @@ impl Global for WlDrmGlobal {
 
     fn version(&self) -> u32 {
         2
+    }
+
+    fn exposed(&self, state: &State) -> bool {
+        let Some(ctx) = state.render_ctx.get() else {
+            return false;
+        };
+        ctx.supports_invalid_modifier()
     }
 }
 


### PR DESCRIPTION
Fixes #418 