### PR TITLE
wl_surface: ignore toplevel damage bounds if toplevel is detached

### DIFF
--- a/src/cpu_worker/tests.rs
+++ b/src/cpu_worker/tests.rs
@@ -6,7 +6,7 @@ use {
         utils::asyncevent::AsyncEvent,
         wheel::Wheel,
     },
-    std::{any::Any, future::pending, rc::Rc, sync::Arc},
+    std::{future::pending, rc::Rc, sync::Arc},
     uapi::{OwnedFd, c::EFD_CLOEXEC},
 };
 

--- a/src/ifs/wl_surface.rs
+++ b/src/ifs/wl_surface.rs
@@ -1453,7 +1453,7 @@ impl WlSurface {
     }
 
     fn apply_damage(&self, pending: &PendingState) {
-        let bounds = self.toplevel.get().map(|tl| tl.node_absolute_position());
+        let bounds = self.toplevel.get().and_then(|tl| tl.tl_render_bounds());
         let pos = self.buffer_abs_pos.get();
         let apply_damage = |pos: Rect| {
             if pending.damage_full {

--- a/src/tree/toplevel.rs
+++ b/src/tree/toplevel.rs
@@ -203,6 +203,13 @@ pub trait ToplevelNodeBase: Node {
         let _ = start;
         default_tile_drag_bounds(self, split)
     }
+
+    fn tl_render_bounds(&self) -> Option<Rect> {
+        self.tl_data()
+            .parent
+            .is_some()
+            .then_some(self.node_absolute_position())
+    }
 }
 
 pub struct FullscreenedData {


### PR DESCRIPTION
Fixes #420 