### PR TITLE
Update README.md discord link to an unexpirable one

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Jay is free software licensed under the GNU General Public License v3.0.
 
 ## Community
 
-[Community Discord server(unofficial)](https://discord.gg/ct9t42Pj)
+[Community Discord server(unofficial)](https://discord.gg/Hby736z28G)


### PR DESCRIPTION
The old link expired after a week from creation, I've set the links to never expire, this one is the new one
In response to a complaint in #407 