### PR TITLE
jay-config: add Seat.get_keyboard_output and Connector.workspaces

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -417,6 +417,12 @@ impl Client {
         workspace
     }
 
+    pub fn get_seat_keyboard_workspace(&self, seat: Seat) -> Workspace {
+        let res = self.send_with_response(&ClientMessage::GetSeatKeyboardWorkspace { seat });
+        get_response!(res, Workspace(0), GetSeatKeyboardWorkspace { workspace });
+        workspace
+    }
+
     pub fn set_default_workspace_capture(&self, capture: bool) {
         self.send(&ClientMessage::SetDefaultWorkspaceCapture { capture });
     }
@@ -1074,6 +1080,19 @@ impl Client {
 
     pub fn set_ei_socket_enabled(&self, enabled: bool) {
         self.send(&ClientMessage::SetEiSocketEnabled { enabled })
+    }
+
+    pub fn get_connector_active_workspace(&self, connector: Connector) -> Workspace {
+        let res =
+            self.send_with_response(&ClientMessage::GetConnectorActiveWorkspace { connector });
+        get_response!(res, Workspace(0), GetConnectorActiveWorkspace { workspace });
+        workspace
+    }
+
+    pub fn get_connector_workspaces(&self, connector: Connector) -> Vec<Workspace> {
+        let res = self.send_with_response(&ClientMessage::GetConnectorWorkspaces { connector });
+        get_response!(res, vec![], GetConnectorWorkspaces { workspaces });
+        workspaces
     }
 
     pub fn latch<F: FnOnce() + 'static>(&self, seat: Seat, f: F) {

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -556,6 +556,15 @@ pub enum ClientMessage<'a> {
     SetShowFloatPinIcon {
         show: bool,
     },
+    GetSeatKeyboardWorkspace {
+        seat: Seat,
+    },
+    GetConnectorActiveWorkspace {
+        connector: Connector,
+    },
+    GetConnectorWorkspaces {
+        connector: Connector,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -709,6 +718,15 @@ pub enum Response {
     },
     GetFloatPinned {
         pinned: bool,
+    },
+    GetSeatKeyboardWorkspace {
+        workspace: Workspace,
+    },
+    GetConnectorActiveWorkspace {
+        workspace: Workspace,
+    },
+    GetConnectorWorkspaces {
+        workspaces: Vec<Workspace>,
     },
 }
 

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -359,6 +359,14 @@ impl Seat {
         get!(Workspace(0)).get_seat_workspace(self)
     }
 
+    /// Returns the workspace that is currently active on the output that contains the seat's
+    /// keyboard focus.
+    ///
+    /// If no such workspace exists, `exists` returns `false` for the returned workspace.
+    pub fn get_keyboard_workspace(self) -> Workspace {
+        get!(Workspace(0)).get_seat_keyboard_workspace(self)
+    }
+
     /// Shows the workspace and sets the keyboard focus of the seat to that workspace.
     ///
     /// If the workspace doesn't currently exist, it is created on the output that contains the

--- a/jay-config/src/video.rs
+++ b/jay-config/src/video.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         _private::WireMode,
-        PciId,
+        PciId, Workspace,
         video::connector_type::{
             CON_9PIN_DIN, CON_COMPONENT, CON_COMPOSITE, CON_DISPLAY_PORT, CON_DPI, CON_DSI,
             CON_DVIA, CON_DVID, CON_DVII, CON_EDP, CON_EMBEDDED_WINDOW, CON_HDMIA, CON_HDMIB,
@@ -300,6 +300,21 @@ impl Connector {
     /// This has no effect unless the vulkan renderer is used.
     pub fn set_brightness(self, brightness: Option<f64>) {
         get!().connector_set_brightness(self, brightness);
+    }
+
+    /// Get the currently visible/active workspace.
+    ///
+    /// If this connector is not connected, or is there no active workspace, returns a
+    /// workspace whose `exists()` returns false.
+    pub fn active_workspace(self) -> Workspace {
+        get!(Workspace(0)).get_connector_active_workspace(self)
+    }
+
+    /// Get all workspaces on this connector.
+    ///
+    /// If this connector is not connected, returns an empty list.
+    pub fn workspaces(self) -> Vec<Workspace> {
+        get!().get_connector_workspaces(self)
     }
 }
 

--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -401,6 +401,10 @@ impl WlSeatGlobal {
         self.cursor_user_group.latest_output()
     }
 
+    pub fn get_keyboard_output(&self) -> Option<Rc<OutputNode>> {
+        self.keyboard_node.get().node_output()
+    }
+
     pub fn set_workspace(&self, ws: &Rc<WorkspaceNode>) {
         let tl = match self.keyboard_node.get().node_toplevel() {
             Some(tl) => tl,

--- a/src/ifs/wl_surface.rs
+++ b/src/ifs/wl_surface.rs
@@ -1783,6 +1783,10 @@ impl Node for WlSurface {
         self.buffer_abs_pos.get()
     }
 
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        Some(self.output.get())
+    }
+
     fn node_active_changed(&self, active: bool) {
         if let Some(tl) = self.toplevel.get() {
             tl.tl_surface_active_changed(active);

--- a/src/ifs/wl_surface/ext_session_lock_surface_v1.rs
+++ b/src/ifs/wl_surface/ext_session_lock_surface_v1.rs
@@ -10,7 +10,7 @@ use {
         leaks::Tracker,
         object::{Object, Version},
         rect::Rect,
-        tree::{FindTreeResult, FindTreeUsecase, FoundNode, Node, NodeId, NodeVisitor},
+        tree::{FindTreeResult, FindTreeUsecase, FoundNode, Node, NodeId, NodeVisitor, OutputNode},
         utils::numcell::NumCell,
         wire::{ExtSessionLockSurfaceV1Id, WlSurfaceId, ext_session_lock_surface_v1::*},
     },
@@ -121,6 +121,10 @@ impl Node for ExtSessionLockSurfaceV1 {
 
     fn node_absolute_position(&self) -> Rect {
         self.surface.node_absolute_position()
+    }
+
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        self.output.node()
     }
 
     fn node_find_tree_at(

--- a/src/ifs/wl_surface/tray.rs
+++ b/src/ifs/wl_surface/tray.rs
@@ -292,6 +292,10 @@ impl<T: TrayItem> Node for T {
         self.data().surface.node_absolute_position()
     }
 
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        self.data().output.node()
+    }
+
     fn node_find_tree_at(
         &self,
         x: i32,

--- a/src/ifs/wl_surface/x_surface/xwindow.rs
+++ b/src/ifs/wl_surface/x_surface/xwindow.rs
@@ -12,7 +12,7 @@ use {
         state::State,
         tree::{
             ContainerSplit, Direction, FindTreeResult, FindTreeUsecase, FoundNode, Node, NodeId,
-            NodeVisitor, StackedNode, TileDragDestination, ToplevelData, ToplevelNode,
+            NodeVisitor, OutputNode, StackedNode, TileDragDestination, ToplevelData, ToplevelNode,
             ToplevelNodeBase, WorkspaceNode, default_tile_drag_destination,
         },
         utils::{clonecell::CloneCell, copyhashmap::CopyHashMap, linkedlist::LinkedNode},
@@ -344,6 +344,10 @@ impl Node for Xwindow {
 
     fn node_absolute_position(&self) -> Rect {
         self.data.info.extents.get()
+    }
+
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        self.toplevel_data.output_opt()
     }
 
     fn node_do_focus(self: Rc<Self>, seat: &Rc<WlSeatGlobal>, _direction: Direction) {

--- a/src/ifs/wl_surface/xdg_surface/xdg_popup.rs
+++ b/src/ifs/wl_surface/xdg_surface/xdg_popup.rs
@@ -314,6 +314,10 @@ impl Node for XdgPopup {
         self.xdg.absolute_desired_extents.get()
     }
 
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        self.xdg.workspace.get().map(|w| w.output.get())
+    }
+
     fn node_find_tree_at(
         &self,
         x: i32,

--- a/src/ifs/wl_surface/xdg_surface/xdg_toplevel.rs
+++ b/src/ifs/wl_surface/xdg_surface/xdg_toplevel.rs
@@ -523,6 +523,10 @@ impl Node for XdgToplevel {
         self.xdg.absolute_desired_extents.get()
     }
 
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        self.toplevel_data.output_opt()
+    }
+
     fn node_do_focus(self: Rc<Self>, seat: &Rc<WlSeatGlobal>, _direction: Direction) {
         seat.focus_toplevel(self.clone());
     }

--- a/src/ifs/wl_surface/zwlr_layer_surface_v1.rs
+++ b/src/ifs/wl_surface/zwlr_layer_surface_v1.rs
@@ -648,6 +648,10 @@ impl Node for ZwlrLayerSurfaceV1 {
         self.pos.get()
     }
 
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        self.output.node()
+    }
+
     fn node_find_tree_at(
         &self,
         x: i32,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -122,6 +122,8 @@ pub trait Node: 'static {
     fn node_visit_children(&self, visitor: &mut dyn NodeVisitor);
     fn node_visible(&self) -> bool;
     fn node_absolute_position(&self) -> Rect;
+    #[expect(dead_code)]
+    fn node_output(&self) -> Option<Rc<OutputNode>>;
 
     fn node_child_title_changed(self: Rc<Self>, child: &dyn Node, title: &str) {
         let _ = child;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -122,7 +122,6 @@ pub trait Node: 'static {
     fn node_visit_children(&self, visitor: &mut dyn NodeVisitor);
     fn node_visible(&self) -> bool;
     fn node_absolute_position(&self) -> Rect;
-    #[expect(dead_code)]
     fn node_output(&self) -> Option<Rc<OutputNode>>;
 
     fn node_child_title_changed(self: Rc<Self>, child: &dyn Node, title: &str) {

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -18,7 +18,7 @@ use {
         text::TextTexture,
         tree::{
             ContainingNode, Direction, FindTreeResult, FindTreeUsecase, FoundNode, Node, NodeId,
-            TddType, TileDragDestination, ToplevelData, ToplevelNode, ToplevelNodeBase,
+            OutputNode, TddType, TileDragDestination, ToplevelData, ToplevelNode, ToplevelNodeBase,
             WorkspaceNode, default_tile_drag_bounds, walker::NodeVisitor,
         },
         utils::{
@@ -1760,6 +1760,10 @@ impl Node for ContainerNode {
 
     fn node_is_container(&self) -> bool {
         true
+    }
+
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        self.toplevel_data.output_opt()
     }
 }
 

--- a/src/tree/display.rs
+++ b/src/tree/display.rs
@@ -146,6 +146,10 @@ impl Node for DisplayNode {
         self.extents.get()
     }
 
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        None
+    }
+
     fn node_find_tree_at(
         &self,
         x: i32,

--- a/src/tree/float.rs
+++ b/src/tree/float.rs
@@ -697,6 +697,10 @@ impl Node for FloatNode {
         self.position.get()
     }
 
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        Some(self.workspace.get().output.get())
+    }
+
     fn node_child_title_changed(self: Rc<Self>, _child: &dyn Node, title: &str) {
         self.update_child_title(title);
     }

--- a/src/tree/output.rs
+++ b/src/tree/output.rs
@@ -1343,6 +1343,10 @@ impl Node for OutputNode {
         self.global.pos.get()
     }
 
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        self.global.opt.node()
+    }
+
     fn node_do_focus(self: Rc<Self>, seat: &Rc<WlSeatGlobal>, direction: Direction) {
         if self.state.lock.locked.get() {
             if let Some(lock) = self.lock_surface.get() {

--- a/src/tree/placeholder.rs
+++ b/src/tree/placeholder.rs
@@ -11,8 +11,8 @@ use {
         text::TextTexture,
         tree::{
             ContainerSplit, Direction, FindTreeResult, FindTreeUsecase, FoundNode, Node, NodeId,
-            NodeVisitor, TileDragDestination, ToplevelData, ToplevelNode, ToplevelNodeBase,
-            default_tile_drag_destination,
+            NodeVisitor, OutputNode, TileDragDestination, ToplevelData, ToplevelNode,
+            ToplevelNodeBase, default_tile_drag_destination,
         },
         utils::{
             asyncevent::AsyncEvent, errorfmt::ErrorFmt, on_drop_event::OnDropEvent,
@@ -200,6 +200,10 @@ impl Node for PlaceholderNode {
 
     fn node_into_toplevel(self: Rc<Self>) -> Option<Rc<dyn ToplevelNode>> {
         Some(self)
+    }
+
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        self.toplevel.output_opt()
     }
 }
 

--- a/src/tree/toplevel.rs
+++ b/src/tree/toplevel.rs
@@ -600,10 +600,14 @@ impl ToplevelData {
     }
 
     pub fn output(&self) -> Rc<OutputNode> {
-        match self.workspace.get() {
+        match self.output_opt() {
             None => self.state.dummy_output.get().unwrap(),
-            Some(ws) => ws.output.get(),
+            Some(o) => o,
         }
+    }
+
+    pub fn output_opt(&self) -> Option<Rc<OutputNode>> {
+        self.workspace.get().map(|ws| ws.output.get())
     }
 
     pub fn desired_pixel_size(&self) -> (i32, i32) {

--- a/src/tree/workspace.rs
+++ b/src/tree/workspace.rs
@@ -298,6 +298,10 @@ impl Node for WorkspaceNode {
         self.position.get()
     }
 
+    fn node_output(&self) -> Option<Rc<OutputNode>> {
+        Some(self.output.get())
+    }
+
     fn node_do_focus(self: Rc<Self>, seat: &Rc<WlSeatGlobal>, direction: Direction) {
         if let Some(fs) = self.fullscreen.get() {
             fs.node_do_focus(seat, direction);


### PR DESCRIPTION
This is a bit of a combined PR with a bunch of separate changes. Please let me know if you'd like me to split each change into individual PRs.

I've been working on my own config setup and found that two pieces of functionality were missing to be able to create my config:

- Get which workspaces are on which outputs, and which workspace is actively being displayed on each output.
- Get which workspace the active keyboard focus is on (not the mouse position)

There's two different ways of doing the first point that I was debating between (they expose equivalent functionality): either `Workspace.get_output` that returns a Connector and a bool for whether it's the active workspace, or `Connector.workspaces` that returns the active workspace, and the list of workspaces on that output. I opted for the latter, mostly arbitrarily.

Additionally, there's some more changes I did in this PR:

- `handle_get_seat_workspace` (called by `Seat.get_workspace`) would fail if `workspaces_by_name` has not been initialized yet. I extracted the common initialization code of `handle_get_workspaces` and `handle_get_workspace` into `get_workspace_by_name`, and am using that same function in the new `handle_get_seat_keyboard_workspace` and `handle_get_connector_workspaces`.

Finally, I'm not 100% sure on the implementation of `WlSeatGlobal.get_keyboard_output` - I don't know if `node_toplevel` is the right function to call there.