### PR TITLE
add desktop entry

### DIFF
--- a/etc/jay.desktop
+++ b/etc/jay.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Jay
+Comment=An i3-inspired Wayland Compositor
+Exec=jay run
+Type=Application
+DesktopNames=jay


### PR DESCRIPTION
This allows jay to be launched from display managers. It only works when jay is installed system-wide, and user-installed applications can't launch on startup(on-graphics-initialized) unless the full path is specified (e.g. /home/.../hybrid-bar instead of hybrid-bar). The former is a nonissue, the latter I feel is unrelated to actually having an entry.

It will main be useful if jay is packaged into an rpm or deb for example