### PR TITLE
xdg-shell: fetch existing extents when surface is created

### DIFF
--- a/src/ifs/wl_surface/xdg_surface.rs
+++ b/src/ifs/wl_surface/xdg_surface.rs
@@ -203,7 +203,7 @@ impl XdgSurface {
             requested_serial: NumCell::new(1),
             acked_serial: Cell::new(None),
             geometry: Cell::new(None),
-            extents: Cell::new(Default::default()),
+            extents: Cell::new(surface.extents.get()),
             absolute_desired_extents: Cell::new(Default::default()),
             ext: Default::default(),
             popup_display_stack: CloneCell::new(surface.client.state.root.stacked.clone()),

--- a/src/ifs/wl_surface/xdg_surface/xdg_toplevel.rs
+++ b/src/ifs/wl_surface/xdg_surface/xdg_toplevel.rs
@@ -157,6 +157,7 @@ impl XdgToplevel {
         toplevel_data
             .content_type
             .set(surface.surface.content_type.get());
+        toplevel_data.pos.set(surface.extents.get());
         Self {
             id,
             state: state.clone(),


### PR DESCRIPTION
The surface might alredy have non-0 extents due to the use of wp_viewporter.