### PR TITLE
ci: add nix shell and package

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,33 @@
+name: nix
+
+concurrency:
+  group: nix-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Check
+        run: nix flake check
+
+      # Debug build with MSRV from Dev Shell in 7m57s
+      # - name: Dev Shell
+      #   run: nix develop -c cargo run -- version
+
+      # Release Build with latest Rust in 11m5s
+      # - name: Build
+      #   run: nix build

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 !/.github
 /target
 /testruns
+result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-only"
 description = "The Jay compositor"
 repository = "https://github.com/mahkoh/jay"
 default-run = "jay"
+rust-version = "1.88.0"  # required by "if- and while-let-chains, take 2"
 
 [[bin]]
 name = "jay"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1753316655,
+        "narHash": "sha256-tzWa2kmTEN69OEMhxFy+J2oWSvZP5QhEgXp3TROOzl0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "f35a3372d070c9e9ccb63ba7ce347f0634ddf3d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753115646,
+        "narHash": "sha256-yLuz5cz5Z+sn8DRAfNkrd2Z1cV6DaYO9JMrEz4KZo/c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "92c2e04a475523e723c67ef872d8037379073681",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753325142,
+        "narHash": "sha256-7A8epLZ/LW9tek4OJY4IHesH7BgfBKr3aEm9JjUwqQo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "cf608fb54d8854f31d7f7c499e2d2c928af48036",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+
+    crane.url = "github:ipetkov/crane";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, crane, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        cargoToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit overlays system;
+        };
+      in
+      {
+        devShells = {
+          default = pkgs.mkShell ({
+            buildInputs = with pkgs; [ 
+              cairomm
+              cmakeMinimal
+              git
+              libgbm
+              libinput
+              libudev-zero
+              pangomm
+              pkg-config
+              pkgs.rust-bin.stable.${cargoToml.package.rust-version}.minimal
+              python3Minimal
+            ];
+          });
+        };
+        packages = (import ./nix/packages.nix { 
+          inherit self pkgs crane;
+          # The default Rust(1.86.0) in 25.05 is older than MSRV, so we use latest one.
+          specificRust = pkgs.rust-bin.stable.latest.minimal;
+        });
+      }
+    );
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,32 @@
+{ self, pkgs, crane, specificRust }:
+let
+  buildInputs = with pkgs; [ 
+    cairomm
+    cmakeMinimal
+    git
+    libgbm
+    libinput
+    libudev-zero
+    pangomm
+    pkg-config
+    python3Minimal
+  ];
+  cargoToml = "${self}/Cargo.toml";
+  cargoTomlConfig = builtins.fromTOML (builtins.readFile cargoToml);
+  craneLib = (crane.mkLib pkgs).overrideToolchain (p: specificRust);
+  doCheck = false;
+  nativeBuildInputs = with pkgs; [ pkg-config ];
+  src = self;
+  version = cargoTomlConfig.package.version;
+in
+rec {
+  default = jay;
+
+  jay = craneLib.buildPackage {
+    inherit buildInputs cargoToml doCheck nativeBuildInputs src version;
+    cargoArtifacts = craneLib.buildDepsOnly {
+      inherit buildInputs src;
+    };
+    pname = "jay";
+  };
+}


### PR DESCRIPTION
Hi there,

Thanks for the project, I am looking for a rust-based Wayland project.  I was a daily user with Qtile/ArchLinux, LeftWM/NixOS for several years, and try to rebuild my environment with this project. 

NixOS users can easier to use a project with `flake.nix` or `shell.nix`(legacy) inside of it.
Dev shell, nix build script, and the minimal support Rust version are added, such that I can easier maintain this in the future.  If these are also good for you and the PR is merged, I will keep maintain this and be a daily testing user.

Thank you.