### PR TITLE
config: workspace display order

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -36,6 +36,7 @@ use {
             ContentType, MatchedWindow, TileState, Window, WindowCriterion, WindowMatcher,
             WindowType,
         },
+        workspace::WorkspaceDisplayOrder,
         xwayland::XScalingMode,
     },
     bincode::Options,
@@ -985,6 +986,10 @@ impl ConfigClient {
 
     pub fn set_middle_click_paste_enabled(&self, enabled: bool) {
         self.send(&ClientMessage::SetMiddleClickPasteEnabled { enabled });
+    }
+
+    pub fn set_workspace_display_order(&self, order: WorkspaceDisplayOrder) {
+        self.send(&ClientMessage::SetWorkspaceDisplayOrder { order });
     }
 
     pub fn seat_create_mark(&self, seat: Seat, kc: Option<u32>) {

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -16,6 +16,7 @@ use {
             Transform, VrrMode, connector_type::ConnectorType,
         },
         window::{ContentType, TileState, Window, WindowMatcher, WindowType},
+        workspace::WorkspaceDisplayOrder,
         xwayland::XScalingMode,
     },
     serde::{Deserialize, Serialize},
@@ -759,6 +760,9 @@ pub enum ClientMessage<'a> {
         seat: Seat,
         src: u32,
         dst: u32,
+    },
+    SetWorkspaceDisplayOrder {
+        order: WorkspaceDisplayOrder,
     },
 }
 

--- a/jay-config/src/lib.rs
+++ b/jay-config/src/lib.rs
@@ -45,6 +45,7 @@
 
 #[expect(unused_imports)]
 use crate::input::Seat;
+
 use {
     crate::{
         _private::ipc::WorkspaceSource, keyboard::ModifiedKeySym, video::Connector, window::Window,
@@ -73,6 +74,7 @@ pub mod theme;
 pub mod timer;
 pub mod video;
 pub mod window;
+pub mod workspace;
 pub mod xwayland;
 
 /// A planar direction.

--- a/jay-config/src/workspace.rs
+++ b/jay-config/src/workspace.rs
@@ -1,0 +1,19 @@
+//! Tools for configuring workspaces.
+
+use serde::{Deserialize, Serialize};
+
+/// How workspaces should be ordered in the UI.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum WorkspaceDisplayOrder {
+    /// Workspaces are not sorted and can be manually dragged.
+    Manual,
+    /// Workspaces are sorted alphabetically and cannot be manually dragged.
+    Sorted,
+}
+
+/// Sets how workspaces should be ordered in the UI.
+///
+/// The default is `WorkspaceDisplayOrder::Manual`.
+pub fn set_workspace_display_order(order: WorkspaceDisplayOrder) {
+    get!().set_workspace_display_order(order);
+}

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -83,6 +83,7 @@ use {
     jay_config::{
         _private::DEFAULT_SEAT_NAME,
         video::{GfxApi, Transform},
+        workspace::WorkspaceDisplayOrder,
     },
     std::{cell::Cell, env, future::Future, ops::Deref, rc::Rc, sync::Arc, time::Duration},
     thiserror::Error,
@@ -357,6 +358,7 @@ fn start_compositor2(
         show_bar: Cell::new(true),
         enable_primary_selection: Cell::new(true),
         xdg_surface_configure_events: Default::default(),
+        workspace_display_order: Cell::new(WorkspaceDisplayOrder::Manual),
     });
     state.tracker.register(ClientId::from_raw(0));
     create_dummy_output(&state);

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -74,6 +74,7 @@ use {
             Transform, VrrMode as ConfigVrrMode,
         },
         window::{TileState, Window, WindowMatcher},
+        workspace::WorkspaceDisplayOrder,
         xwayland::XScalingMode,
     },
     kbvm::Keycode,
@@ -1350,6 +1351,13 @@ impl ConfigProxyHandler {
             if let Some(float) = stacked.deref().clone().node_into_float() {
                 float.schedule_render_titles();
             }
+        }
+    }
+
+    fn handle_set_workspace_display_order(&self, order: WorkspaceDisplayOrder) {
+        self.state.workspace_display_order.set(order);
+        for output in self.state.root.outputs.lock().values() {
+            output.handle_workspace_display_order_update();
         }
     }
 
@@ -3097,6 +3105,9 @@ impl ConfigProxyHandler {
             }
             ClientMessage::SetMiddleClickPasteEnabled { enabled } => {
                 self.handle_set_middle_click_paste_enabled(enabled)
+            }
+            ClientMessage::SetWorkspaceDisplayOrder { order } => {
+                self.handle_set_workspace_display_order(order)
             }
             ClientMessage::SeatCreateMark { seat, kc } => self
                 .handle_seat_create_mark(seat, kc)

--- a/src/state.rs
+++ b/src/state.rs
@@ -128,6 +128,7 @@ use {
         PciId,
         video::{GfxApi, Transform},
         window::TileState,
+        workspace::WorkspaceDisplayOrder,
     },
     std::{
         cell::{Cell, RefCell},
@@ -275,6 +276,7 @@ pub struct State {
     pub show_bar: Cell<bool>,
     pub enable_primary_selection: Cell<bool>,
     pub xdg_surface_configure_events: AsyncQueue<XdgSurfaceConfigureEvent>,
+    pub workspace_display_order: Cell<WorkspaceDisplayOrder>,
 }
 
 // impl Drop for State {

--- a/src/tree/workspace.rs
+++ b/src/tree/workspace.rs
@@ -35,6 +35,7 @@ use {
         },
         wire::JayWorkspaceId,
     },
+    jay_config::workspace::WorkspaceDisplayOrder,
     std::{
         cell::{Cell, RefCell},
         fmt::Debug,
@@ -491,8 +492,15 @@ pub fn move_ws_to_output(
         }
     }
     ws.set_output(&target);
+    let before = if target.state.workspace_display_order.get() == WorkspaceDisplayOrder::Sorted {
+        target
+            .find_workspace_insertion_point(&ws.name)
+            .map(|nr| nr.deref().clone())
+    } else {
+        config.before
+    };
     'link: {
-        if let Some(before) = config.before
+        if let Some(before) = before
             && let Some(link) = &*before.output_link.borrow()
         {
             link.prepend_existing(ws);

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -35,6 +35,7 @@ use {
         theme::Color,
         video::{ColorSpace, Format, GfxApi, TearingMode, TransferFunction, Transform, VrrMode},
         window::{ContentType, TileState, WindowType},
+        workspace::WorkspaceDisplayOrder,
         xwayland::XScalingMode,
     },
     std::{
@@ -509,6 +510,7 @@ pub struct Config {
     pub focus_history: Option<FocusHistory>,
     pub middle_click_paste: Option<bool>,
     pub input_modes: AHashMap<String, InputMode>,
+    pub workspace_display_order: Option<WorkspaceDisplayOrder>,
 }
 
 #[derive(Debug, Error)]

--- a/toml-config/src/config/parsers.rs
+++ b/toml-config/src/config/parsers.rs
@@ -47,6 +47,7 @@ mod vrr;
 mod window_match;
 mod window_rule;
 mod window_type;
+mod workspace_display_order;
 mod xwayland;
 
 #[derive(Debug, Error)]

--- a/toml-config/src/config/parsers/config.rs
+++ b/toml-config/src/config/parsers/config.rs
@@ -36,6 +36,7 @@ use {
                 ui_drag::UiDragParser,
                 vrr::VrrParser,
                 window_rule::WindowRulesParser,
+                workspace_display_order::WorkspaceDisplayOrderParser,
                 xwayland::XwaylandParser,
             },
             spanned::SpannedErrorExt,
@@ -138,7 +139,7 @@ impl Parser for ConfigParser<'_> {
                 show_bar,
                 focus_history_val,
             ),
-            (middle_click_paste, input_modes_val),
+            (middle_click_paste, input_modes_val, workspace_display_order_val),
         ) = ext.extract((
             (
                 opt(val("keymap")),
@@ -188,7 +189,11 @@ impl Parser for ConfigParser<'_> {
                 recover(opt(bol("show-bar"))),
                 opt(val("focus-history")),
             ),
-            (recover(opt(bol("middle-click-paste"))), opt(val("modes"))),
+            (
+                recover(opt(bol("middle-click-paste"))),
+                opt(val("modes")),
+                opt(val("workspace-display-order")),
+            ),
         ))?;
         let mut keymap = None;
         if let Some(value) = keymap_val {
@@ -486,6 +491,18 @@ impl Parser for ConfigParser<'_> {
                 }
             }
         }
+        let mut workspace_display_order = None;
+        if let Some(value) = workspace_display_order_val {
+            match value.parse(&mut WorkspaceDisplayOrderParser) {
+                Ok(v) => workspace_display_order = Some(v),
+                Err(e) => {
+                    log::warn!(
+                        "Could not parse the workspace display order: {}",
+                        self.0.error(e)
+                    );
+                }
+            }
+        }
         Ok(Config {
             keymap,
             repeat_rate,
@@ -528,6 +545,7 @@ impl Parser for ConfigParser<'_> {
             focus_history,
             middle_click_paste: middle_click_paste.despan(),
             input_modes,
+            workspace_display_order,
         })
     }
 }

--- a/toml-config/src/config/parsers/workspace_display_order.rs
+++ b/toml-config/src/config/parsers/workspace_display_order.rs
@@ -1,0 +1,32 @@
+use {
+    crate::{
+        config::parser::{DataType, ParseResult, Parser, UnexpectedDataType},
+        toml::toml_span::{Span, SpannedExt},
+    },
+    jay_config::workspace::WorkspaceDisplayOrder,
+    thiserror::Error,
+};
+
+#[derive(Debug, Error)]
+pub enum WorkspaceDisplayOrderParserError {
+    #[error(transparent)]
+    Expected(#[from] UnexpectedDataType),
+    #[error("Unknown workspace display order {0}")]
+    Unknown(String),
+}
+
+pub struct WorkspaceDisplayOrderParser;
+
+impl Parser for WorkspaceDisplayOrderParser {
+    type Value = WorkspaceDisplayOrder;
+    type Error = WorkspaceDisplayOrderParserError;
+    const EXPECTED: &'static [DataType] = &[DataType::String];
+
+    fn parse_string(&mut self, span: Span, string: &str) -> ParseResult<Self> {
+        match string {
+            "manual" => Ok(WorkspaceDisplayOrder::Manual),
+            "sorted" => Ok(WorkspaceDisplayOrder::Sorted),
+            _ => Err(WorkspaceDisplayOrderParserError::Unknown(string.to_string()).spanned(span)),
+        }
+    }
+}

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -50,6 +50,7 @@ use {
             set_tearing_mode, set_vrr_cursor_hz, set_vrr_mode,
         },
         window::Window,
+        workspace::set_workspace_display_order,
         xwayland::set_x_scaling_mode,
     },
     run_on_drop::on_drop,
@@ -1305,6 +1306,9 @@ fn load_config(initial_load: bool, persistent: &Rc<PersistentState>) {
     }
     if let Some(v) = config.middle_click_paste {
         set_middle_click_paste_enabled(v);
+    }
+    if let Some(v) = config.workspace_display_order {
+        set_workspace_display_order(v);
     }
 }
 

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -991,6 +991,10 @@
             "description": "",
             "$ref": "#/$defs/InputMode"
           }
+        },
+        "workspace-display-order": {
+          "description": "Configures the order of workspaces displayed.\n\nThe default is `manual`.\n\n- Example:\n\n  ```toml\n  workspace-display-order = \"sorted\"\n  ```\n",
+          "$ref": "#/$defs/WorkspaceDisplayOrder"
         }
       },
       "required": []
@@ -2177,6 +2181,14 @@
             "$ref": "#/$defs/WindowTypeMask"
           }
         }
+      ]
+    },
+    "WorkspaceDisplayOrder": {
+      "type": "string",
+      "description": "The order of workspaces displayed.\n",
+      "enum": [
+        "manual",
+        "sorted"
       ]
     },
     "XScalingMode": {

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -1976,6 +1976,20 @@ The table has the following fields:
 
   The value of this field should be a table whose values are [InputModes](#types-InputMode).
 
+- `workspace-display-order` (optional):
+
+  Configures the order of workspaces displayed.
+  
+  The default is `manual`.
+  
+  - Example:
+  
+    ```toml
+    workspace-display-order = "sorted"
+    ```
+
+  The value of this field should be a [WorkspaceDisplayOrder](#types-WorkspaceDisplayOrder).
+
 
 <a name="types-Connector"></a>
 ### `Connector`
@@ -4759,6 +4773,25 @@ The string should have one of the following values:
 An array of masks that are OR'd.
 
 Each element of this array should be a [WindowTypeMask](#types-WindowTypeMask).
+
+
+<a name="types-WorkspaceDisplayOrder"></a>
+### `WorkspaceDisplayOrder`
+
+The order of workspaces displayed.
+
+Values of this type should be strings.
+
+The string should have one of the following values:
+
+- `manual`:
+
+  Workspaces are not sorted and can be manually dragged.
+
+- `sorted`:
+
+  Workspaces are sorted alphabetically and cannot be manually dragged.
+
 
 
 <a name="types-XScalingMode"></a>

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -2122,7 +2122,6 @@ Theme:
       description: The name of the font to use.
 
 
-
 Config:
   kind: table
   description: |
@@ -2802,8 +2801,21 @@ Config:
           q = "focus-prev"
           e = "focus-next"
           ```
-        
+
         Modes can be activated with the `push-mode` and `latch-mode` actions.
+    workspace-display-order:
+      ref: WorkspaceDisplayOrder
+      required: false
+      description: |
+        Configures the order of workspaces displayed.
+
+        The default is `manual`.
+
+        - Example:
+
+          ```toml
+          workspace-display-order = "sorted"
+          ```
 
 
 Idle:
@@ -4006,3 +4018,14 @@ InputMode:
         The complex shortcuts of this mode.
         
         See the same field in the top-level `Config` object for a description.
+
+
+WorkspaceDisplayOrder:
+  kind: string
+  description: |
+    The order of workspaces displayed.
+  values:
+    - value: manual
+      description: Workspaces are not sorted and can be manually dragged.
+    - value: sorted
+      description: Workspaces are sorted alphabetically and cannot be manually dragged.


### PR DESCRIPTION
Point 1 from #519 done as we talked about here https://github.com/mahkoh/jay/pull/541#issuecomment-3120275757.

- considered natural sorting but decided it's probably not worth it
- maintains a sorted linked list of workspaces if workspace-display-order is set to sorted, handles workspace creation, drag, move-to-output
- O(N) search to find an appropriate place to insert a workspace, but it's only on user actions and it's unlikely there's ever going to be many of them, so should be fine