### PR TITLE
cmm: ignore backend luminance with the default EOTF

### DIFF
--- a/jay-config/src/video.rs
+++ b/jay-config/src/video.rs
@@ -304,6 +304,10 @@ impl Connector {
     /// This should only be used with the PQ transfer function. If the default transfer
     /// function is used, you should instead calibrate the hardware directly.
     ///
+    /// When used with the default transfer function, the default brightness is anchored
+    /// at 80 cd/m^2. That is, setting this to 40 cd/m^2 makes everything appear half as
+    /// bright as normal and creates 50% HDR headroom.
+    ///
     /// This has no effect unless the vulkan renderer is used.
     pub fn set_brightness(self, brightness: Option<f64>) {
         get!().connector_set_brightness(self, brightness);

--- a/src/cli/randr.rs
+++ b/src/cli/randr.rs
@@ -386,6 +386,10 @@ pub struct BrightnessArgs {
     /// When using the default EOTF, you likely want to set this to `default`
     /// and adjust the display hardware brightness setting instead.
     ///
+    /// When used with the default transfer function, the default brightness is anchored
+    /// at 80 cd/m^2. That is, setting this to 40 cd/m^2 makes everything appear half as
+    /// bright as normal and creates 50% HDR headroom.
+    ///
     /// This has no effect unless the vulkan renderer is used.
     #[clap(verbatim_doc_comment, value_parser = parse_brightness)]
     brightness: Brightness,

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -857,6 +857,10 @@ The string should have one of the following values:
   
   - `default`: The maximum brightness of the output.
   - `PQ`: 203 cd/m^2
+  
+  When used with the default transfer function, the default brightness is anchored
+  at 80 cd/m^2. That is, setting this to 40 cd/m^2 makes everything appear half as
+  bright as normal and creates 50% HDR headroom.
 
 
 #### A number

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -3425,6 +3425,10 @@ Brightness:
             
             - `default`: The maximum brightness of the output.
             - `PQ`: 203 cd/m^2
+            
+            When used with the default transfer function, the default brightness is anchored
+            at 80 cd/m^2. That is, setting this to 40 cd/m^2 makes everything appear half as
+            bright as normal and creates 50% HDR headroom.
     - kind: number
       description: |
         The brightness in cd/m^2.


### PR DESCRIPTION
Closes #644 