### PR TITLE
Add a simple, XCompose based input method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ linearize = { version = "0.1.3", features = ["derive"] }
 png = "0.18.0"
 rustc-demangle = { version = "0.1.24", optional = true }
 tracy-client-sys = { version = "0.24.1", features = ["ondemand", "manual-lifetime", "debuginfod", "demangle"], optional = true }
-kbvm = "0.1.5"
+kbvm = { version = "0.1.5", features = ["compose"] }
 tiny-skia = { version = "0.11.4", default-features = false, features = ["std"] }
 regex = "1.11.1"
 cfg-if = "1.0.0"

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -1040,6 +1040,10 @@ impl ConfigClient {
         self.send(&ClientMessage::SeatReloadSimpleIm { seat });
     }
 
+    pub fn seat_enable_unicode_input(&self, seat: Seat) {
+        self.send(&ClientMessage::SeatEnableUnicodeInput { seat });
+    }
+
     pub fn set_show_float_pin_icon(&self, show: bool) {
         self.send(&ClientMessage::SetShowFloatPinIcon { show });
     }

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -1026,6 +1026,20 @@ impl ConfigClient {
         self.send(&ClientMessage::SeatCopyMark { seat, src, dst });
     }
 
+    pub fn seat_set_simple_im_enabled(&self, seat: Seat, enabled: bool) {
+        self.send(&ClientMessage::SeatSetSimpleImEnabled { seat, enabled });
+    }
+
+    pub fn seat_get_simple_im_enabled(&self, seat: Seat) -> bool {
+        let res = self.send_with_response(&ClientMessage::SeatGetSimpleImEnabled { seat });
+        get_response!(res, false, SeatGetSimpleImEnabled { enabled });
+        enabled
+    }
+
+    pub fn seat_reload_simple_im(&self, seat: Seat) {
+        self.send(&ClientMessage::SeatReloadSimpleIm { seat });
+    }
+
     pub fn set_show_float_pin_icon(&self, show: bool) {
         self.send(&ClientMessage::SetShowFloatPinIcon { show });
     }

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -798,6 +798,9 @@ pub enum ClientMessage<'a> {
     SeatReloadSimpleIm {
         seat: Seat,
     },
+    SeatEnableUnicodeInput {
+        seat: Seat,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -788,6 +788,16 @@ pub enum ClientMessage<'a> {
         workspace: Workspace,
         connector: Connector,
     },
+    SeatSetSimpleImEnabled {
+        seat: Seat,
+        enabled: bool,
+    },
+    SeatGetSimpleImEnabled {
+        seat: Seat,
+    },
+    SeatReloadSimpleIm {
+        seat: Seat,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -1019,6 +1029,9 @@ pub enum Response {
     },
     GetShowBar {
         show: bool,
+    },
+    SeatGetSimpleImEnabled {
+        enabled: bool,
     },
 }
 

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -603,6 +603,34 @@ impl Seat {
     pub fn copy_mark(self, src: u32, dst: u32) {
         get!().seat_copy_mark(self, src, dst);
     }
+
+    /// Sets whether the simple, XCompose based input method is enabled.
+    ///
+    /// Regardless of this setting, this input method is not used if an external input
+    /// method is running.
+    ///
+    /// The default is `true`.
+    pub fn set_simple_im_enabled(self, enabled: bool) {
+        get!().seat_set_simple_im_enabled(self, enabled);
+    }
+
+    /// Returns whether the simple, XCompose based input method is enabled.
+    pub fn simple_im_enabled(self) -> bool {
+        get!(true).seat_get_simple_im_enabled(self)
+    }
+
+    /// Toggles whether the simple, XCompose based input method is enabled.
+    pub fn toggle_simple_im_enabled(self) {
+        let get = get!();
+        get.seat_set_simple_im_enabled(self, !get.seat_get_simple_im_enabled(self));
+    }
+
+    /// Reloads the simple, XCompose based input method.
+    ///
+    /// This is useful if you change the XCompose files after starting the compositor.
+    pub fn reload_simple_im(self) {
+        get!().seat_reload_simple_im(self);
+    }
 }
 
 /// A focus-follows-mouse mode.

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -631,6 +631,13 @@ impl Seat {
     pub fn reload_simple_im(self) {
         get!().seat_reload_simple_im(self);
     }
+
+    /// Enables Unicode input in the simple, XCompose based input method.
+    ///
+    /// This has no effect if the simple IM is not currently active.
+    pub fn enable_unicode_input(self) {
+        get!().seat_enable_unicode_input(self);
+    }
 }
 
 /// A focus-follows-mouse mode.

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -2281,6 +2281,26 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
+    fn handle_seat_set_simple_im_enabled(&self, seat: Seat, enabled: bool) -> Result<(), CphError> {
+        let seat = self.get_seat(seat)?;
+        seat.set_simple_im_enabled(enabled);
+        Ok(())
+    }
+
+    fn handle_seat_get_simple_im_enabled(&self, seat: Seat) -> Result<(), CphError> {
+        let seat = self.get_seat(seat)?;
+        self.respond(Response::SeatGetSimpleImEnabled {
+            enabled: seat.simple_im_enabled(),
+        });
+        Ok(())
+    }
+
+    fn handle_seat_reload_simple_im(&self, seat: Seat) -> Result<(), CphError> {
+        let seat = self.get_seat(seat)?;
+        seat.reload_simple_im();
+        Ok(())
+    }
+
     fn spaces_change(&self) {
         struct V;
         impl NodeVisitorBase for V {
@@ -3216,6 +3236,15 @@ impl ConfigProxyHandler {
             } => self
                 .handle_show_workspace(seat, workspace, Some(connector))
                 .wrn("show_workspace_on")?,
+            ClientMessage::SeatSetSimpleImEnabled { seat, enabled } => self
+                .handle_seat_set_simple_im_enabled(seat, enabled)
+                .wrn("seat_set_simple_im_enabled")?,
+            ClientMessage::SeatGetSimpleImEnabled { seat } => self
+                .handle_seat_get_simple_im_enabled(seat)
+                .wrn("seat_get_simple_im_enabled")?,
+            ClientMessage::SeatReloadSimpleIm { seat } => self
+                .handle_seat_reload_simple_im(seat)
+                .wrn("seat_reload_simple_im")?,
         }
         Ok(())
     }

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -2301,6 +2301,12 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
+    fn handle_seat_enable_unicode_input(&self, seat: Seat) -> Result<(), CphError> {
+        let seat = self.get_seat(seat)?;
+        seat.enable_unicode_input();
+        Ok(())
+    }
+
     fn spaces_change(&self) {
         struct V;
         impl NodeVisitorBase for V {
@@ -3245,6 +3251,9 @@ impl ConfigProxyHandler {
             ClientMessage::SeatReloadSimpleIm { seat } => self
                 .handle_seat_reload_simple_im(seat)
                 .wrn("seat_reload_simple_im")?,
+            ClientMessage::SeatEnableUnicodeInput { seat } => self
+                .handle_seat_enable_unicode_input(seat)
+                .wrn("seat_enable_unicode_input")?,
         }
         Ok(())
     }

--- a/src/gfx_api.rs
+++ b/src/gfx_api.rs
@@ -955,7 +955,7 @@ pub fn create_render_pass(
         for seat in seats.values() {
             let (x, y) = seat.pointer_cursor().position_int();
             if let Some(im) = seat.input_method() {
-                for (_, popup) in &im.popups {
+                for (_, popup) in im.popups() {
                     if popup.surface.node_visible() {
                         let pos = popup.surface.buffer_abs_pos.get();
                         let extents = popup.surface.extents.get().move_(pos.x1(), pos.y1());

--- a/src/ifs/jay_compositor.rs
+++ b/src/ifs/jay_compositor.rs
@@ -79,7 +79,7 @@ impl Global for JayCompositorGlobal {
     }
 
     fn version(&self) -> u32 {
-        21
+        22
     }
 
     fn required_caps(&self) -> ClientCaps {

--- a/src/ifs/jay_input.rs
+++ b/src/ifs/jay_input.rs
@@ -515,6 +515,30 @@ impl JayInputRequestHandler for JayInput {
             Ok(())
         })
     }
+
+    fn set_simple_im_enabled(
+        &self,
+        req: SetSimpleImEnabled<'_>,
+        _slf: &Rc<Self>,
+    ) -> Result<(), Self::Error> {
+        self.or_error(|| {
+            let seat = self.seat(req.seat)?;
+            seat.set_simple_im_enabled(req.enabled != 0);
+            Ok(())
+        })
+    }
+
+    fn reload_simple_im(
+        &self,
+        req: ReloadSimpleIm<'_>,
+        _slf: &Rc<Self>,
+    ) -> Result<(), Self::Error> {
+        self.or_error(|| {
+            let seat = self.seat(req.seat)?;
+            seat.reload_simple_im();
+            Ok(())
+        })
+    }
 }
 
 object_base! {

--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -239,6 +239,7 @@ pub struct WlSeatGlobal {
     modifiers_listener: EventListener<dyn LedsListener>,
     modifiers_forward: EventSource<dyn LedsListener>,
     simple_im: CloneCell<Option<Rc<SimpleIm>>>,
+    simple_im_enabled: Cell<bool>,
 }
 
 #[derive(Copy, Clone)]
@@ -330,6 +331,7 @@ impl WlSeatGlobal {
             modifiers_listener: EventListener::new(slf.clone()),
             modifiers_forward: Default::default(),
             simple_im: CloneCell::new(simple_im),
+            simple_im_enabled: Cell::new(true),
         });
         slf.pointer_cursor.set_owner(slf.clone());
         slf.modifiers_listener

--- a/src/ifs/wl_seat/text_input.rs
+++ b/src/ifs/wl_seat/text_input.rs
@@ -42,6 +42,7 @@ pub trait InputMethod {
     fn done(self: Rc<Self>, seat: &WlSeatGlobal);
     fn is_simple(&self) -> bool;
     fn cancel_simple(&self, seat: &WlSeatGlobal);
+    fn enable_unicode_input(&self);
 }
 
 pub trait InputMethodKeyboardGrab {
@@ -64,6 +65,12 @@ pub enum TextDisconnectReason {
 }
 
 impl WlSeatGlobal {
+    pub fn enable_unicode_input(&self) {
+        if let Some(im) = self.input_method.get() {
+            im.enable_unicode_input();
+        }
+    }
+
     pub fn set_simple_im_enabled(self: &Rc<Self>, enabled: bool) {
         if self.simple_im_enabled.replace(enabled) == enabled {
             return;

--- a/src/ifs/wl_seat/text_input.rs
+++ b/src/ifs/wl_seat/text_input.rs
@@ -110,5 +110,10 @@ impl TextInputConnection {
                 popup.update_visible();
             }
         }
+        if reason != TextDisconnectReason::TextInputDisabled {
+            self.text_input.send_preedit_string(None, 0, 0);
+            self.text_input.send_commit_string(None);
+            self.text_input.send_done();
+        }
     }
 }

--- a/src/ifs/wl_seat/text_input/simple_im.rs
+++ b/src/ifs/wl_seat/text_input/simple_im.rs
@@ -1,0 +1,204 @@
+use {
+    crate::{
+        backend::KeyState,
+        ifs::{
+            wl_seat::{
+                WlSeatGlobal,
+                text_input::{
+                    InputMethod, InputMethodKeyboardGrab, TextDisconnectReason, TextInputConnection,
+                },
+            },
+            wl_surface::zwp_input_popup_surface_v2::ZwpInputPopupSurfaceV2,
+        },
+        keyboard::KeyboardState,
+        utils::{clonecell::CloneCell, smallmap::SmallMap},
+        wire::ZwpInputPopupSurfaceV2Id,
+    },
+    kbvm::{
+        Keycode, ModifierMask, syms,
+        xkb::{
+            self,
+            compose::{self, FeedResult},
+            diagnostic::WriteToLog,
+        },
+    },
+    std::{
+        cell::{Cell, RefCell},
+        rc::Rc,
+    },
+};
+
+pub struct SimpleIm {
+    con: CloneCell<Option<Rc<TextInputConnection>>>,
+    popups: SmallMap<ZwpInputPopupSurfaceV2Id, Rc<ZwpInputPopupSurfaceV2>, 1>,
+    active: Cell<bool>,
+    activate: Cell<Option<bool>>,
+    table: compose::ComposeTable,
+    initial_state: compose::State,
+    states: RefCell<Vec<State>>,
+}
+
+struct State {
+    state: compose::State,
+    char: char,
+}
+
+impl SimpleIm {
+    pub fn new(ctx: &xkb::Context) -> Option<Rc<Self>> {
+        let table = ctx.compose_table_builder().build(WriteToLog)?;
+        Some(Rc::new(Self {
+            con: Default::default(),
+            popups: Default::default(),
+            active: Default::default(),
+            activate: Default::default(),
+            states: Default::default(),
+            initial_state: table.create_state(),
+            table,
+        }))
+    }
+}
+
+impl InputMethod for SimpleIm {
+    fn set_connection(&self, con: Option<&Rc<TextInputConnection>>) {
+        self.con.set(con.cloned());
+    }
+
+    fn popups(&self) -> &SmallMap<ZwpInputPopupSurfaceV2Id, Rc<ZwpInputPopupSurfaceV2>, 1> {
+        &self.popups
+    }
+
+    fn activate(&self) {
+        self.activate.set(Some(true));
+    }
+
+    fn deactivate(&self) {
+        self.activate.set(Some(false));
+    }
+
+    fn content_type(&self, _hint: u32, _purpose: u32) {
+        // nothing
+    }
+
+    fn text_change_cause(&self, _cause: u32) {
+        // nothing
+    }
+
+    fn surrounding_text(&self, _text: &str, _cursor: u32, _anchor: u32) {
+        // nothing
+    }
+
+    fn done(self: Rc<Self>, seat: &WlSeatGlobal) {
+        let Some(active) = self.activate.take() else {
+            return;
+        };
+        self.active.set(active);
+        if active {
+            self.states.borrow_mut().clear();
+            seat.input_method_grab.set(Some(self));
+        } else {
+            seat.input_method_grab.take();
+        }
+    }
+
+    fn is_simple(&self) -> bool {
+        true
+    }
+
+    fn cancel_simple(&self, seat: &WlSeatGlobal) {
+        seat.input_method_grab.take();
+        if let Some(con) = self.con.get() {
+            con.disconnect(TextDisconnectReason::InputMethodDestroyed);
+        }
+    }
+}
+
+impl InputMethodKeyboardGrab for SimpleIm {
+    fn on_key(&self, _time_usec: u64, key: u32, state: KeyState, kb_state: &KeyboardState) -> bool {
+        if state != KeyState::Pressed {
+            return true;
+        }
+        let Some(con) = self.con.get() else {
+            return true;
+        };
+        let mut buf = [0; 4];
+        let mut forward_to_node = true;
+        let states = &mut *self.states.borrow_mut();
+        let lookup = kb_state.map.lookup_table.lookup(
+            kb_state.mods.group,
+            kb_state.mods.mods,
+            Keycode::from_evdev(key),
+        );
+        let mods = lookup.remaining_mods();
+        let is_control = mods.contains(ModifierMask::CONTROL);
+        for sym in lookup {
+            let sym = sym.keysym();
+            let mut new_state = states
+                .last()
+                .map(|s| s.state.clone())
+                .unwrap_or_else(|| self.initial_state.clone());
+            let Some(fr) = self.table.feed(&mut new_state, sym) else {
+                continue;
+            };
+            forward_to_node = false;
+            let mut send_preedit = |char: char| {
+                let s = char.encode_utf8(&mut buf);
+                let len = s.len() as i32;
+                con.text_input.send_preedit_string(Some(s), len, len);
+            };
+            match fr {
+                FeedResult::Pending => {
+                    let char = sym.char().unwrap_or('·');
+                    states.push(State {
+                        state: new_state,
+                        char,
+                    });
+                    send_preedit(char);
+                    con.text_input.send_done();
+                }
+                FeedResult::Aborted
+                    if sym == syms::Escape || (matches!(sym, syms::c | syms::w) && is_control) =>
+                {
+                    states.clear();
+                    con.text_input.send_preedit_string(None, 0, 0);
+                    con.text_input.send_done();
+                }
+                FeedResult::Aborted if sym == syms::BackSpace => {
+                    states.pop();
+                    if let Some(state) = states.last() {
+                        send_preedit(state.char);
+                    } else {
+                        con.text_input.send_preedit_string(None, 0, 0);
+                    }
+                    con.text_input.send_done();
+                }
+                FeedResult::Aborted => {
+                    // nothing
+                }
+                FeedResult::Composed { string, keysym } => {
+                    states.clear();
+                    let s = if string.is_some() {
+                        string
+                    } else if let Some(sym) = keysym
+                        && let Some(char) = sym.char()
+                    {
+                        Some(char.encode_utf8(&mut buf) as &str)
+                    } else {
+                        None
+                    };
+                    con.text_input.send_preedit_string(None, 0, 0);
+                    con.text_input.send_commit_string(s);
+                    con.text_input.send_done();
+                }
+            }
+        }
+        forward_to_node
+    }
+
+    fn on_modifiers(&self, _kb_state: &KeyboardState) -> bool {
+        true
+    }
+
+    fn on_repeat_info(&self) {
+        // nothing
+    }
+}

--- a/src/ifs/wl_seat/text_input/zwp_input_method_manager_v2.rs
+++ b/src/ifs/wl_seat/text_input/zwp_input_method_manager_v2.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         client::{CAP_INPUT_METHOD, Client, ClientCaps, ClientError},
         globals::{Global, GlobalName},
-        ifs::wl_seat::text_input::{TextConnectReason, zwp_input_method_v2::ZwpInputMethodV2},
+        ifs::wl_seat::text_input::zwp_input_method_v2::ZwpInputMethodV2,
         leaks::Tracker,
         object::{Object, Version},
         wire::{ZwpInputMethodManagerV2Id, zwp_input_method_manager_v2::*},
@@ -72,7 +72,7 @@ impl ZwpInputMethodManagerV2RequestHandler for ZwpInputMethodManagerV2 {
 
     fn get_input_method(&self, req: GetInputMethod, _slf: &Rc<Self>) -> Result<(), Self::Error> {
         let seat = self.client.lookup(req.seat)?;
-        let inert = seat.global.input_method.is_some();
+        let inert = seat.global.cannot_set_new_im();
         let im = Rc::new(ZwpInputMethodV2 {
             id: req.input_method,
             client: self.client.clone(),
@@ -90,9 +90,7 @@ impl ZwpInputMethodManagerV2RequestHandler for ZwpInputMethodManagerV2 {
         if inert {
             im.send_unavailable();
         } else {
-            seat.global.input_method.set(Some(im));
-            seat.global
-                .create_text_input_connection(TextConnectReason::InputMethodCreated);
+            seat.global.set_input_method(im);
         }
         Ok(())
     }

--- a/src/ifs/wl_seat/text_input/zwp_input_method_v2.rs
+++ b/src/ifs/wl_seat/text_input/zwp_input_method_v2.rs
@@ -144,6 +144,10 @@ impl InputMethod for ZwpInputMethodV2 {
     fn cancel_simple(&self, _seat: &WlSeatGlobal) {
         unreachable!();
     }
+
+    fn enable_unicode_input(&self) {
+        // nothing
+    }
 }
 
 impl ZwpInputMethodV2RequestHandler for ZwpInputMethodV2 {

--- a/src/ifs/wl_seat/text_input/zwp_input_method_v2.rs
+++ b/src/ifs/wl_seat/text_input/zwp_input_method_v2.rs
@@ -5,7 +5,7 @@ use {
             wl_seat::{
                 WlSeatGlobal,
                 text_input::{
-                    MAX_TEXT_SIZE, TextDisconnectReason, TextInputConnection,
+                    InputMethod, MAX_TEXT_SIZE, TextDisconnectReason, TextInputConnection,
                     zwp_input_method_keyboard_grab_v2::ZwpInputMethodKeyboardGrabV2,
                 },
             },
@@ -101,6 +101,40 @@ impl ZwpInputMethodV2 {
 
     pub fn send_unavailable(&self) {
         self.client.event(Unavailable { self_id: self.id });
+    }
+}
+
+impl InputMethod for ZwpInputMethodV2 {
+    fn set_connection(&self, con: Option<&Rc<TextInputConnection>>) {
+        self.connection.set(con.cloned());
+    }
+
+    fn popups(&self) -> &SmallMap<ZwpInputPopupSurfaceV2Id, Rc<ZwpInputPopupSurfaceV2>, 1> {
+        &self.popups
+    }
+
+    fn activate(&self) {
+        self.activate();
+    }
+
+    fn deactivate(&self) {
+        self.send_deactivate();
+    }
+
+    fn content_type(&self, hint: u32, purpose: u32) {
+        self.send_content_type(hint, purpose);
+    }
+
+    fn text_change_cause(&self, cause: u32) {
+        self.send_text_change_cause(cause);
+    }
+
+    fn surrounding_text(&self, text: &str, cursor: u32, anchor: u32) {
+        self.send_surrounding_text(text, cursor, anchor);
+    }
+
+    fn done(self: Rc<Self>, _seat: &WlSeatGlobal) {
+        (*self).send_done();
     }
 }
 

--- a/src/ifs/wl_seat/text_input/zwp_input_method_v2.rs
+++ b/src/ifs/wl_seat/text_input/zwp_input_method_v2.rs
@@ -53,7 +53,7 @@ impl ZwpInputMethodV2 {
         }
         self.popups.clear();
         if !self.inert {
-            self.seat.input_method.take();
+            self.seat.remove_input_method();
         }
     }
 
@@ -135,6 +135,14 @@ impl InputMethod for ZwpInputMethodV2 {
 
     fn done(self: Rc<Self>, _seat: &WlSeatGlobal) {
         (*self).send_done();
+    }
+
+    fn is_simple(&self) -> bool {
+        false
+    }
+
+    fn cancel_simple(&self, _seat: &WlSeatGlobal) {
+        unreachable!();
     }
 }
 

--- a/src/ifs/wl_surface.rs
+++ b/src/ifs/wl_surface.rs
@@ -784,7 +784,7 @@ impl WlSurface {
             }
         }
         for (_, con) in &self.text_input_connections {
-            for (_, popup) in &con.input_method.popups {
+            for (_, popup) in con.input_method.popups() {
                 popup.schedule_positioning();
             }
         }

--- a/src/tools/tool_client.rs
+++ b/src/tools/tool_client.rs
@@ -335,7 +335,7 @@ impl ToolClient {
             self_id: s.registry,
             name: s.jay_compositor.0,
             interface: JayCompositor.name(),
-            version: s.jay_compositor.1.min(21),
+            version: s.jay_compositor.1.min(22),
             id: id.into(),
         });
         self.jay_compositor.set(Some(id));

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -88,6 +88,7 @@ pub enum SimpleCommand {
     EnableSimpleIm(bool),
     ToggleSimpleImEnabled,
     ReloadSimpleIm,
+    EnableUnicodeInput,
 }
 
 #[derive(Debug, Clone)]

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -85,6 +85,9 @@ pub enum SimpleCommand {
     CreateMark,
     JumpToMark,
     PopMode(bool),
+    EnableSimpleIm(bool),
+    ToggleSimpleImEnabled,
+    ReloadSimpleIm,
 }
 
 #[derive(Debug, Clone)]
@@ -447,6 +450,11 @@ pub struct Vrr {
 }
 
 #[derive(Debug, Clone)]
+pub struct SimpleIm {
+    pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
 pub struct Xwayland {
     pub scaling_mode: Option<XScalingMode>,
 }
@@ -520,6 +528,7 @@ pub struct Config {
     pub middle_click_paste: Option<bool>,
     pub input_modes: AHashMap<String, InputMode>,
     pub workspace_display_order: Option<WorkspaceDisplayOrder>,
+    pub simple_im: Option<SimpleIm>,
 }
 
 #[derive(Debug, Error)]

--- a/toml-config/src/config/parsers.rs
+++ b/toml-config/src/config/parsers.rs
@@ -39,6 +39,7 @@ mod output;
 mod output_match;
 mod repeat_rate;
 pub mod shortcuts;
+mod simple_im;
 mod status;
 mod tearing;
 mod theme;

--- a/toml-config/src/config/parsers/action.rs
+++ b/toml-config/src/config/parsers/action.rs
@@ -159,6 +159,7 @@ impl ActionParser<'_> {
             "disable-simple-im" => EnableSimpleIm(false),
             "toggle-simple-im-enabled" => ToggleSimpleImEnabled,
             "reload-simple-im" => ReloadSimpleIm,
+            "enable-unicode-input" => EnableUnicodeInput,
             _ => {
                 return Err(
                     ActionParserError::UnknownSimpleAction(string.to_string()).spanned(span)

--- a/toml-config/src/config/parsers/action.rs
+++ b/toml-config/src/config/parsers/action.rs
@@ -155,6 +155,10 @@ impl ActionParser<'_> {
             "jump-to-mark" => JumpToMark,
             "clear-modes" => PopMode(false),
             "pop-mode" => PopMode(true),
+            "enable-simple-im" => EnableSimpleIm(true),
+            "disable-simple-im" => EnableSimpleIm(false),
+            "toggle-simple-im-enabled" => ToggleSimpleImEnabled,
+            "reload-simple-im" => ReloadSimpleIm,
             _ => {
                 return Err(
                     ActionParserError::UnknownSimpleAction(string.to_string()).spanned(span)

--- a/toml-config/src/config/parsers/config.rs
+++ b/toml-config/src/config/parsers/config.rs
@@ -30,6 +30,7 @@ use {
                     ComplexShortcutsParser, ShortcutsParser, ShortcutsParserError,
                     parse_modified_keysym_str,
                 },
+                simple_im::SimpleImParser,
                 status::StatusParser,
                 tearing::TearingParser,
                 theme::ThemeParser,
@@ -139,7 +140,13 @@ impl Parser for ConfigParser<'_> {
                 show_bar,
                 focus_history_val,
             ),
-            (middle_click_paste, input_modes_val, workspace_display_order_val, auto_reload),
+            (
+                middle_click_paste,
+                input_modes_val,
+                workspace_display_order_val,
+                auto_reload,
+                simple_im_val,
+            ),
         ) = ext.extract((
             (
                 opt(val("keymap")),
@@ -194,6 +201,7 @@ impl Parser for ConfigParser<'_> {
                 opt(val("modes")),
                 opt(val("workspace-display-order")),
                 recover(opt(bol("auto-reload"))),
+                opt(val("simple-im")),
             ),
         ))?;
         let mut keymap = None;
@@ -505,6 +513,15 @@ impl Parser for ConfigParser<'_> {
                 }
             }
         }
+        let mut simple_im = None;
+        if let Some(value) = simple_im_val {
+            match value.parse(&mut SimpleImParser(self.0)) {
+                Ok(v) => simple_im = Some(v),
+                Err(e) => {
+                    log::warn!("Could not parse simple IM setting: {}", self.0.error(e));
+                }
+            }
+        }
         Ok(Config {
             keymap,
             repeat_rate,
@@ -549,6 +566,7 @@ impl Parser for ConfigParser<'_> {
             middle_click_paste: middle_click_paste.despan(),
             input_modes,
             workspace_display_order,
+            simple_im,
         })
     }
 }

--- a/toml-config/src/config/parsers/simple_im.rs
+++ b/toml-config/src/config/parsers/simple_im.rs
@@ -1,0 +1,44 @@
+use {
+    crate::{
+        config::{
+            SimpleIm,
+            context::Context,
+            extractor::{Extractor, ExtractorError, bol, opt, recover},
+            parser::{DataType, ParseResult, Parser, UnexpectedDataType},
+        },
+        toml::{
+            toml_span::{DespanExt, Span, Spanned},
+            toml_value::Value,
+        },
+    },
+    indexmap::IndexMap,
+    thiserror::Error,
+};
+
+#[derive(Debug, Error)]
+pub enum SimpleImParserError {
+    #[error(transparent)]
+    Expected(#[from] UnexpectedDataType),
+    #[error(transparent)]
+    Extract(#[from] ExtractorError),
+}
+
+pub struct SimpleImParser<'a>(pub &'a Context<'a>);
+
+impl Parser for SimpleImParser<'_> {
+    type Value = SimpleIm;
+    type Error = SimpleImParserError;
+    const EXPECTED: &'static [DataType] = &[DataType::Table];
+
+    fn parse_table(
+        &mut self,
+        span: Span,
+        table: &IndexMap<Spanned<String>, Spanned<Value>>,
+    ) -> ParseResult<Self> {
+        let mut ext = Extractor::new(self.0, span, table);
+        let (enabled,) = ext.extract((recover(opt(bol("enabled"))),))?;
+        Ok(SimpleIm {
+            enabled: enabled.despan(),
+        })
+    }
+}

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -236,6 +236,10 @@ impl Action {
                     let persistent = state.persistent.clone();
                     b.new(move || persistent.seat.reload_simple_im())
                 }
+                SimpleCommand::EnableUnicodeInput => {
+                    let persistent = state.persistent.clone();
+                    b.new(move || persistent.seat.enable_unicode_input())
+                }
             },
             Action::Multi { actions } => {
                 let actions: Vec<_> = actions.into_iter().map(|a| a.into_fn(state)).collect();

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -224,6 +224,18 @@ impl Action {
                     let state = state.clone();
                     b.new(move || state.pop_mode(pop))
                 }
+                SimpleCommand::EnableSimpleIm(v) => {
+                    let persistent = state.persistent.clone();
+                    b.new(move || persistent.seat.set_simple_im_enabled(v))
+                }
+                SimpleCommand::ToggleSimpleImEnabled => {
+                    let persistent = state.persistent.clone();
+                    b.new(move || persistent.seat.toggle_simple_im_enabled())
+                }
+                SimpleCommand::ReloadSimpleIm => {
+                    let persistent = state.persistent.clone();
+                    b.new(move || persistent.seat.reload_simple_im())
+                }
             },
             Action::Multi { actions } => {
                 let actions: Vec<_> = actions.into_iter().map(|a| a.into_fn(state)).collect();
@@ -1558,6 +1570,11 @@ fn load_config(initial_load: bool, auto_reload: bool, persistent: &Rc<Persistent
     }
     if let Some(v) = config.workspace_display_order {
         set_workspace_display_order(v);
+    }
+    if let Some(simple_im) = config.simple_im {
+        if let Some(enabled) = simple_im.enabled {
+            persistent.seat.set_simple_im_enabled(enabled);
+        }
     }
 }
 

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -1843,7 +1843,8 @@
         "enable-simple-im",
         "disable-simple-im",
         "toggle-simple-im-enabled",
-        "reload-simple-im"
+        "reload-simple-im",
+        "enable-unicode-input"
       ]
     },
     "SimpleIm": {

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -361,7 +361,7 @@
               ]
             },
             {
-              "description": "Sets the log level of the compositor..\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-j = { type = \"set-log-level\", level = \"debug\" }\n  ```\n",
+              "description": "Sets the log level of the compositor.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-j = { type = \"set-log-level\", level = \"debug\" }\n  ```\n",
               "type": "object",
               "properties": {
                 "type": {
@@ -1049,6 +1049,10 @@
         "workspace-display-order": {
           "description": "Configures the order of workspaces displayed.\n\nThe default is `manual`.\n\n- Example:\n\n  ```toml\n  workspace-display-order = \"sorted\"\n  ```\n",
           "$ref": "#/$defs/WorkspaceDisplayOrder"
+        },
+        "simple-im": {
+          "description": "Configures the simple, XCompose based input method.\n\nBy default, the input method is enabled. \n\nEven if the input method is enabled, it will only be used if there is no\nrunning external IM.\n\n- Example:\n\n  ```toml\n  [simple-im]\n  enabled = false\n  ```\n",
+          "$ref": "#/$defs/SimpleIm"
         }
       },
       "required": []
@@ -1835,8 +1839,23 @@
         "create-mark",
         "jump-to-mark",
         "clear-modes",
-        "pop-mode"
+        "pop-mode",
+        "enable-simple-im",
+        "disable-simple-im",
+        "toggle-simple-im-enabled",
+        "reload-simple-im"
       ]
+    },
+    "SimpleIm": {
+      "description": "Describes the settings of the simple, XCompose based input method.\n\n- Example:\n\n  ```toml\n  [simple-im]\n  enabled = false\n  ```\n",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the input method is enabled.\n\nEven if the input method is enabled, it will only be used if there is no\nrunning external IM.\n"
+        }
+      },
+      "required": []
     },
     "Status": {
       "description": "The configuration of a status program whose output will be shown in the bar.\n\n- Example:\n\n  ```toml\n  [status]\n  format = \"i3bar\"\n  exec = \"i3status\"\n  ```\n",

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -538,7 +538,7 @@ This table is a tagged union. The variant is determined by the `type` field. It 
 
 - `set-log-level`:
 
-  Sets the log level of the compositor..
+  Sets the log level of the compositor.
   
   - Example:
   
@@ -2144,6 +2144,24 @@ The table has the following fields:
     ```
 
   The value of this field should be a [WorkspaceDisplayOrder](#types-WorkspaceDisplayOrder).
+
+- `simple-im` (optional):
+
+  Configures the simple, XCompose based input method.
+  
+  By default, the input method is enabled. 
+  
+  Even if the input method is enabled, it will only be used if there is no
+  running external IM.
+  
+  - Example:
+  
+    ```toml
+    [simple-im]
+    enabled = false
+    ```
+
+  The value of this field should be a [SimpleIm](#types-SimpleIm).
 
 
 <a name="types-Connector"></a>
@@ -4177,6 +4195,53 @@ The string should have one of the following values:
 
   Pops the topmost mode from the input-mode stack.
 
+- `enable-simple-im`:
+
+  Enables the simple, XCompose based input method.
+  
+  Even if the input method is enabled, it will only be used if there is no
+  running external IM.
+
+- `disable-simple-im`:
+
+  Disables the simple, XCompose based input method.
+
+- `toggle-simple-im-enabled`:
+
+  Toggles whether the simple, XCompose based input method is enabled.
+
+- `reload-simple-im`:
+
+  Reloads the simple, XCompose based input method.
+  
+  This is useful if you change the XCompose files after starting the compositor.
+
+
+
+<a name="types-SimpleIm"></a>
+### `SimpleIm`
+
+Describes the settings of the simple, XCompose based input method.
+
+- Example:
+
+  ```toml
+  [simple-im]
+  enabled = false
+  ```
+
+Values of this type should be tables.
+
+The table has the following fields:
+
+- `enabled` (optional):
+
+  Whether the input method is enabled.
+  
+  Even if the input method is enabled, it will only be used if there is no
+  running external IM.
+
+  The value of this field should be a boolean.
 
 
 <a name="types-Status"></a>

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -4216,6 +4216,12 @@ The string should have one of the following values:
   
   This is useful if you change the XCompose files after starting the compositor.
 
+- `enable-unicode-input`:
+
+  Enables Unicode input in the simple, XCompose based input method.
+  
+  This has no effect if the simple IM is not currently active.
+
 
 
 <a name="types-SimpleIm"></a>

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -1050,6 +1050,11 @@ SimpleActionName:
         Reloads the simple, XCompose based input method.
         
         This is useful if you change the XCompose files after starting the compositor.
+    - value: enable-unicode-input
+      description: |
+        Enables Unicode input in the simple, XCompose based input method.
+       
+        This has no effect if the simple IM is not currently active.
 
 
 Color:

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -497,7 +497,7 @@ Action:
               ref: Theme
         set-log-level:
           description: |
-            Sets the log level of the compositor..
+            Sets the log level of the compositor.
             
             - Example:
             
@@ -1033,6 +1033,23 @@ SimpleActionName:
       description: Disables all previously set input modes, clearing the input-mode stack.
     - value: pop-mode
       description: Pops the topmost mode from the input-mode stack.
+    - value: enable-simple-im
+      description: |
+        Enables the simple, XCompose based input method.
+        
+        Even if the input method is enabled, it will only be used if there is no
+        running external IM.
+    - value: disable-simple-im
+      description: |
+        Disables the simple, XCompose based input method.
+    - value: toggle-simple-im-enabled
+      description: |
+        Toggles whether the simple, XCompose based input method is enabled.
+    - value: reload-simple-im
+      description: |
+        Reloads the simple, XCompose based input method.
+        
+        This is useful if you change the XCompose files after starting the compositor.
 
 
 Color:
@@ -2881,6 +2898,23 @@ Config:
           ```toml
           workspace-display-order = "sorted"
           ```
+    simple-im:
+      ref: SimpleIm
+      required: false
+      description: |
+        Configures the simple, XCompose based input method.
+        
+        By default, the input method is enabled. 
+        
+        Even if the input method is enabled, it will only be used if there is no
+        running external IM.
+
+        - Example:
+        
+          ```toml
+          [simple-im]
+          enabled = false
+          ```
 
 
 Idle:
@@ -4195,3 +4229,25 @@ ClientCapabilities:
       description: An array of masks that are OR'd.
       items:
         ref: ClientCapabilities
+
+
+SimpleIm:
+  kind: table
+  description: |
+    Describes the settings of the simple, XCompose based input method.
+    
+    - Example:
+    
+      ```toml
+      [simple-im]
+      enabled = false
+      ```
+  fields:
+    enabled:
+      kind: boolean
+      required: false
+      description: |
+        Whether the input method is enabled.
+        
+        Even if the input method is enabled, it will only be used if there is no
+        running external IM.

--- a/wire/jay_input.txt
+++ b/wire/jay_input.txt
@@ -134,6 +134,15 @@ request set_middle_button_emulation (since = 19) {
     enabled: u32,
 }
 
+request set_simple_im_enabled (since = 22) {
+    seat: str,
+    enabled: u32,
+}
+
+request reload_simple_im (since = 22) {
+    seat: str,
+}
+
 # events
 
 event seat {


### PR DESCRIPTION
Since GTK no longer uses XCompose, this restores the previous functionality.

In addition to XCompose, users can also input unicode by invoking the enable-unicode-input action.