### PR TITLE
feat(toml-config): Add directional output selection for move-to-output action

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -1385,6 +1385,31 @@ impl ConfigClient {
         workspaces
     }
 
+    /// Returns the connector that the workspace is currently on.
+    /// Returns `Connector(0)` (invalid connector) if the workspace doesn't exist or
+    /// isn't assigned to any connector.
+    pub fn get_workspace_connector(&self, workspace: Workspace) -> Connector {
+        let res = self.send_with_response(&ClientMessage::GetWorkspaceConnector { workspace });
+        get_response!(res, Connector(0), GetWorkspaceConnector { connector });
+        connector
+    }
+
+    /// Finds the connector in the specified direction from the given connector.
+    /// Returns `Connector(0)` (invalid connector) if no connector exists in that direction
+    /// or if the source connector is invalid.
+    pub fn get_connector_in_direction(
+        &self,
+        connector: Connector,
+        direction: Direction,
+    ) -> Connector {
+        let res = self.send_with_response(&ClientMessage::GetConnectorInDirection {
+            connector,
+            direction,
+        });
+        get_response!(res, Connector(0), GetConnectorInDirection { connector });
+        connector
+    }
+
     pub fn set_client_matcher_capabilities(
         &self,
         matcher: ClientMatcher,

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -805,6 +805,13 @@ pub enum ClientMessage<'a> {
         show: bool,
     },
     GetShowTitles,
+    GetWorkspaceConnector {
+        workspace: Workspace,
+    },
+    GetConnectorInDirection {
+        connector: Connector,
+        direction: Direction,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -1042,6 +1049,12 @@ pub enum Response {
     },
     GetShowTitles {
         show: bool,
+    },
+    GetWorkspaceConnector {
+        connector: Connector,
+    },
+    GetConnectorInDirection {
+        connector: Connector,
     },
 }
 

--- a/jay-config/src/lib.rs
+++ b/jay-config/src/lib.rs
@@ -186,6 +186,13 @@ impl Workspace {
     pub fn window(self) -> Window {
         get!(Window(0)).get_workspace_window(self)
     }
+
+    /// Returns the connector that contains this workspace.
+    ///
+    /// If no such connector exists, [`Connector::exists`] returns false.
+    pub fn connector(self) -> Connector {
+        get!(Connector(0)).get_workspace_connector(self)
+    }
 }
 
 /// Returns the workspace with the given name.

--- a/jay-config/src/video.rs
+++ b/jay-config/src/video.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         _private::WireMode,
-        PciId, Workspace,
+        Direction, PciId, Workspace,
         video::connector_type::{
             CON_9PIN_DIN, CON_COMPONENT, CON_COMPOSITE, CON_DISPLAY_PORT, CON_DPI, CON_DSI,
             CON_DVIA, CON_DVID, CON_DVII, CON_EDP, CON_EMBEDDED_WINDOW, CON_HDMIA, CON_HDMIB,
@@ -326,6 +326,17 @@ impl Connector {
     /// If this connector is not connected, returns an empty list.
     pub fn workspaces(self) -> Vec<Workspace> {
         get!().get_connector_workspaces(self)
+    }
+
+    /// Find the closest connector in the given direction.
+    ///
+    /// Uses center-to-center distance calculation and prefers outputs better aligned
+    /// with the movement axis.
+    ///
+    /// If no connector exists in the given direction, returns a connector whose
+    /// `exists()` returns false.
+    pub fn connector_in_direction(self, direction: Direction) -> Connector {
+        get!(Connector(0)).get_connector_in_direction(self, direction)
     }
 }
 

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -160,7 +160,8 @@ pub enum Action {
     },
     MoveToOutput {
         workspace: Option<Workspace>,
-        output: OutputMatch,
+        output: Option<OutputMatch>,
+        direction: Option<Direction>,
     },
     SetRepeatRate {
         rate: RepeatRate,

--- a/toml-config/src/config/extractor.rs
+++ b/toml-config/src/config/extractor.rs
@@ -47,6 +47,10 @@ impl<'v> Extractor<'v> {
         self.log_unused = false;
     }
 
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
     pub fn extract<E: Extractable<'v>, U>(&mut self, e: E) -> Result<E::Output, Spanned<U>>
     where
         ExtractorError: Into<U>,

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -163,7 +163,7 @@
               ]
             },
             {
-              "description": "Moves a workspace to a different output.\n\n- Example 1:\n\n  ```toml\n  [shortcuts]\n  alt-F1 = { type = \"move-to-output\", workspace = \"1\", output.name = \"right\" }\n  ```\n\n- Example 2:\n\n  ```toml\n  [shortcuts]\n  alt-F1 = { type = \"move-to-output\", output.name = \"right\" }\n  ```\n",
+              "description": "Moves a workspace to a different output.\n\n- Example 1: Move a specific workspace to a named output\n\n  ```toml\n  [shortcuts]\n  alt-F1 = { type = \"move-to-output\", workspace = \"1\", output.name = \"right\" }\n  ```\n\n- Example 2: Move the current workspace to a named output\n\n  ```toml\n  [shortcuts]\n  alt-F1 = { type = \"move-to-output\", output.name = \"right\" }\n  ```\n\n- Example 3: Move the current workspace to the output on the right (directional)\n\n  ```toml\n  [shortcuts]\n  \"logo+ctrl+shift+Right\" = { type = \"move-to-output\", direction = \"right\" }\n  \"logo+ctrl+shift+Left\" = { type = \"move-to-output\", direction = \"left\" }\n  \"logo+ctrl+shift+Up\" = { type = \"move-to-output\", direction = \"up\" }\n  \"logo+ctrl+shift+Down\" = { type = \"move-to-output\", direction = \"down\" }\n  ```\n",
               "type": "object",
               "properties": {
                 "type": {
@@ -174,13 +174,16 @@
                   "description": "The name of the workspace.\n\nIf this is omitted, the currently active workspace is moved.\n"
                 },
                 "output": {
-                  "description": "The output to move to.\n\nIf multiple outputs match, the workspace is moved to the first matching\noutput.\n",
+                  "description": "The output to move to.\n\nIf multiple outputs match, the workspace is moved to the first matching\noutput.\n\nEither `output` or `direction` must be specified, but not both.\n",
                   "$ref": "#/$defs/OutputMatch"
+                },
+                "direction": {
+                  "description": "The direction to search for the next output.\n\nFinds the closest output in the specified direction based on\ncenter-to-center distance, with preference for outputs better aligned\nwith the movement axis.\n\nEither `output` or `direction` must be specified, but not both.\n",
+                  "$ref": "#/$defs/Direction"
                 }
               },
               "required": [
-                "type",
-                "output"
+                "type"
               ]
             },
             {
@@ -1124,6 +1127,16 @@
             "$ref": "#/$defs/ContentTypeMask"
           }
         }
+      ]
+    },
+    "Direction": {
+      "type": "string",
+      "description": "A directional value used for output selection.\n",
+      "enum": [
+        "left",
+        "right",
+        "up",
+        "down"
       ]
     },
     "DrmDevice": {

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -290,18 +290,28 @@ This table is a tagged union. The variant is determined by the `type` field. It 
 
   Moves a workspace to a different output.
   
-  - Example 1:
+  - Example 1: Move a specific workspace to a named output
   
     ```toml
     [shortcuts]
     alt-F1 = { type = "move-to-output", workspace = "1", output.name = "right" }
     ```
   
-  - Example 2:
+  - Example 2: Move the current workspace to a named output
   
     ```toml
     [shortcuts]
     alt-F1 = { type = "move-to-output", output.name = "right" }
+    ```
+  
+  - Example 3: Move the current workspace to the output on the right (directional)
+  
+    ```toml
+    [shortcuts]
+    "logo+ctrl+shift+Right" = { type = "move-to-output", direction = "right" }
+    "logo+ctrl+shift+Left" = { type = "move-to-output", direction = "left" }
+    "logo+ctrl+shift+Up" = { type = "move-to-output", direction = "up" }
+    "logo+ctrl+shift+Down" = { type = "move-to-output", direction = "down" }
     ```
 
   The table has the following fields:
@@ -314,14 +324,28 @@ This table is a tagged union. The variant is determined by the `type` field. It 
 
     The value of this field should be a string.
 
-  - `output` (required):
+  - `output` (optional):
 
     The output to move to.
     
     If multiple outputs match, the workspace is moved to the first matching
     output.
+    
+    Either `output` or `direction` must be specified, but not both.
 
     The value of this field should be a [OutputMatch](#types-OutputMatch).
+
+  - `direction` (optional):
+
+    The direction to search for the next output.
+    
+    Finds the closest output in the specified direction based on
+    center-to-center distance, with preference for outputs better aligned
+    with the movement axis.
+    
+    Either `output` or `direction` must be specified, but not both.
+
+    The value of this field should be a [Direction](#types-Direction).
 
 - `configure-connector`:
 
@@ -2283,6 +2307,33 @@ The string should have one of the following values:
 An array of masks that are OR'd.
 
 Each element of this array should be a [ContentTypeMask](#types-ContentTypeMask).
+
+
+<a name="types-Direction"></a>
+### `Direction`
+
+A directional value used for output selection.
+
+Values of this type should be strings.
+
+The string should have one of the following values:
+
+- `left`:
+
+  The left direction.
+
+- `right`:
+
+  The right direction.
+
+- `up`:
+
+  The up direction.
+
+- `down`:
+
+  The down direction.
+
 
 
 <a name="types-DrmDevice"></a>

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -288,18 +288,28 @@ Action:
           description: |
             Moves a workspace to a different output.
             
-            - Example 1:
+            - Example 1: Move a specific workspace to a named output
             
               ```toml
               [shortcuts]
               alt-F1 = { type = "move-to-output", workspace = "1", output.name = "right" }
               ```
             
-            - Example 2:
+            - Example 2: Move the current workspace to a named output
             
               ```toml
               [shortcuts]
               alt-F1 = { type = "move-to-output", output.name = "right" }
+              ```
+
+            - Example 3: Move the current workspace to the output on the right (directional)
+
+              ```toml
+              [shortcuts]
+              "logo+ctrl+shift+Right" = { type = "move-to-output", direction = "right" }
+              "logo+ctrl+shift+Left" = { type = "move-to-output", direction = "left" }
+              "logo+ctrl+shift+Up" = { type = "move-to-output", direction = "up" }
+              "logo+ctrl+shift+Down" = { type = "move-to-output", direction = "down" }
               ```
           fields:
             workspace:
@@ -315,8 +325,21 @@ Action:
                 
                 If multiple outputs match, the workspace is moved to the first matching
                 output.
-              required: true
+
+                Either `output` or `direction` must be specified, but not both.
+              required: false
               ref: OutputMatch
+            direction:
+              description: |
+                The direction to search for the next output.
+
+                Finds the closest output in the specified direction based on
+                center-to-center distance, with preference for outputs better aligned
+                with the movement axis.
+
+                Either `output` or `direction` must be specified, but not both.
+              required: false
+              ref: Direction
         configure-connector:
           description: |
             Applies a configuration to connectors.
@@ -4191,6 +4214,21 @@ BlendSpace:
       description: The sRGB blend space. This is the classic desktop blend space.
     - value: linear
       description: Linear color space. This is the physically correct blend space.
+
+
+Direction:
+  kind: string
+  description: |
+    A directional value used for output selection.
+  values:
+    - value: left
+      description: The left direction.
+    - value: right
+      description: The right direction.
+    - value: up
+      description: The up direction.
+    - value: down
+      description: The down direction.
 
 
 ClientCapabilities:


### PR DESCRIPTION
Add support for directional output matching using string values ("left", "right", "up", "down") in the move-to-output action. The algorithm finds the closest output in the specified direction based on center-to-center distance, with preference for outputs better aligned with the movement axis.

This addresses #660