### PR TITLE
Add mouse-refocus option to center cursor on focused window

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -1064,6 +1064,10 @@ impl ConfigClient {
         self.send(&ClientMessage::SeatEnableUnicodeInput { seat });
     }
 
+    pub fn seat_set_mouse_refocus(&self, seat: Seat, enabled: bool) {
+        self.send(&ClientMessage::SeatSetMouseRefocus { seat, enabled });
+    }
+
     pub fn set_show_float_pin_icon(&self, show: bool) {
         self.send(&ClientMessage::SetShowFloatPinIcon { show });
     }

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -816,6 +816,10 @@ pub enum ClientMessage<'a> {
         position: BarPosition,
     },
     GetBarPosition,
+    SeatSetMouseRefocus {
+        seat: Seat,
+        enabled: bool,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -638,6 +638,14 @@ impl Seat {
     pub fn enable_unicode_input(self) {
         get!().seat_enable_unicode_input(self);
     }
+
+    /// Sets whether the cursor should automatically move to the center of a window
+    /// when focus changes via keyboard commands (move-left, focus-right, show-workspace, etc.).
+    ///
+    /// Default: false.
+    pub fn set_mouse_refocus(self, enabled: bool) {
+        get!().seat_set_mouse_refocus(self, enabled)
+    }
 }
 
 /// A focus-follows-mouse mode.

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -2355,6 +2355,12 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
+    fn handle_seat_set_mouse_refocus(&self, seat: Seat, enabled: bool) -> Result<(), CphError> {
+        let seat = self.get_seat(seat)?;
+        seat.set_mouse_refocus(enabled);
+        Ok(())
+    }
+
     fn spaces_change(&self) {
         struct V;
         impl NodeVisitorBase for V {
@@ -3316,6 +3322,9 @@ impl ConfigProxyHandler {
             ClientMessage::SeatEnableUnicodeInput { seat } => self
                 .handle_seat_enable_unicode_input(seat)
                 .wrn("seat_enable_unicode_input")?,
+            ClientMessage::SeatSetMouseRefocus { seat, enabled } => self
+                .handle_seat_set_mouse_refocus(seat, enabled)
+                .wrn("seat_set_mouse_refocus")?,
         }
         Ok(())
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -925,6 +925,9 @@ impl State {
             }
         };
         self.show_workspace2(Some(seat), &ws.output.get(), &ws);
+        if seat.mouse_refocus.get() {
+            seat.warp_cursor_to_focused_window();
+        }
     }
 
     pub fn float_map_ws(&self) -> Rc<WorkspaceNode> {

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -536,6 +536,7 @@ pub struct Config {
     pub input_modes: AHashMap<String, InputMode>,
     pub workspace_display_order: Option<WorkspaceDisplayOrder>,
     pub simple_im: Option<SimpleIm>,
+    pub mouse_refocus: Option<bool>,
 }
 
 #[derive(Debug, Error)]

--- a/toml-config/src/config/parsers/config.rs
+++ b/toml-config/src/config/parsers/config.rs
@@ -147,6 +147,7 @@ impl Parser for ConfigParser<'_> {
                 auto_reload,
                 simple_im_val,
                 show_titles,
+                mouse_refocus,
             ),
         ) = ext.extract((
             (
@@ -204,6 +205,7 @@ impl Parser for ConfigParser<'_> {
                 recover(opt(bol("auto-reload"))),
                 opt(val("simple-im")),
                 recover(opt(bol("show-titles"))),
+                recover(opt(bol("mouse-refocus"))),
             ),
         ))?;
         let mut keymap = None;
@@ -570,6 +572,7 @@ impl Parser for ConfigParser<'_> {
             input_modes,
             workspace_display_order,
             simple_im,
+            mouse_refocus: mouse_refocus.despan(),
         })
     }
 }

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -1624,6 +1624,9 @@ fn load_config(initial_load: bool, auto_reload: bool, persistent: &Rc<Persistent
             persistent.seat.set_simple_im_enabled(enabled);
         }
     }
+    if let Some(mouse_refocus) = config.mouse_refocus {
+        persistent.seat.set_mouse_refocus(mouse_refocus);
+    }
 }
 
 fn create_command(exec: &Exec) -> Command {

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -966,7 +966,7 @@
         },
         "focus-follows-mouse": {
           "type": "boolean",
-          "description": "Configures whether moving the mouse over a window automatically moves the keyboard\nfocus to that window.\n\nThe default is `true`.\n"
+          "description": "Configures whether moving the mouse over a window automatically moves the keyboard\nfocus to that window.\n\nThe default is `false`.\n"
         },
         "window-management-key": {
           "type": "string",
@@ -1068,6 +1068,10 @@
         "simple-im": {
           "description": "Configures the simple, XCompose based input method.\n\nBy default, the input method is enabled. \n\nEven if the input method is enabled, it will only be used if there is no\nrunning external IM.\n\n- Example:\n\n  ```toml\n  [simple-im]\n  enabled = false\n  ```\n",
           "$ref": "#/$defs/SimpleIm"
+        },
+        "mouse-refocus": {
+          "type": "boolean",
+          "description": "Configures whether the mouse cursor is automatically centered on the active window\nwhen focus changes via keyboard commands.\n\nWhen enabled, the cursor will be automatically positioned to the center of the\nactive window when focus changes through keyboard commands such as `focus-left`,\n`focus-right`, `show-workspace`, etc.\n\nThe default is `true`.\n\n- Example:\n\n  ```toml\n  mouse-refocus = false\n  ```\n"
         }
       },
       "required": []

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -1903,7 +1903,7 @@ The table has the following fields:
   Configures whether moving the mouse over a window automatically moves the keyboard
   focus to that window.
   
-  The default is `true`.
+  The default is `false`.
 
   The value of this field should be a boolean.
 
@@ -2217,6 +2217,25 @@ The table has the following fields:
     ```
 
   The value of this field should be a [SimpleIm](#types-SimpleIm).
+
+- `mouse-refocus` (optional):
+
+  Configures whether the mouse cursor is automatically centered on the active window
+  when focus changes via keyboard commands.
+  
+  When enabled, the cursor will be automatically positioned to the center of the
+  active window when focus changes through keyboard commands such as `focus-left`,
+  `focus-right`, `show-workspace`, etc.
+  
+  The default is `true`.
+  
+  - Example:
+  
+    ```toml
+    mouse-refocus = false
+    ```
+
+  The value of this field should be a boolean.
 
 
 <a name="types-Connector"></a>

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -2669,7 +2669,7 @@ Config:
         Configures whether moving the mouse over a window automatically moves the keyboard
         focus to that window.
 
-        The default is `true`.
+        The default is `false`.
     window-management-key:
       kind: string
       required: false
@@ -2966,7 +2966,24 @@ Config:
           [simple-im]
           enabled = false
           ```
+    mouse-refocus:
+      kind: boolean
+      required: false
+      description: |
+        Configures whether the mouse cursor is automatically centered on the active window
+        when focus changes via keyboard commands.
 
+        When enabled, the cursor will be automatically positioned to the center of the
+        active window when focus changes through keyboard commands such as `focus-left`,
+        `focus-right`, `show-workspace`, etc.
+
+        The default is `true`.
+
+        - Example:
+
+          ```toml
+          mouse-refocus = false
+          ```
 
 Idle:
   kind: table


### PR DESCRIPTION
Implement automatic cursor positioning to the center of the active
window when focus changes via keyboard commands (move-left, focus-right,
show-workspace, etc.). This feature is enabled by default but can be
disabled in config.toml with `mouse-refocus = false`.