### PR TITLE
toml-spec: compliant $id in schema

### DIFF
--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -1,5 +1,5 @@
 {
-  "$id": "jay_toml_schema",
+  "$id": "urn:jay_toml_schema",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$ref": "#/$defs/Config",
   "$defs": {

--- a/toml-spec/src/json_schema.rs
+++ b/toml-spec/src/json_schema.rs
@@ -16,7 +16,7 @@ pub fn generate_json_schema(
     }
 
     let json = json!({
-        "$id": "jay_toml_schema",
+        "$id": "urn:jay_toml_schema",
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$ref": "#/$defs/Config",
         "$defs": types,


### PR DESCRIPTION
Make `$id` compliant with [JSON Schema spec](https://www.learnjsonschema.com/2020-12/core/id/).

This allows using tools like [taplo](https://taplo.tamasfe.dev/configuration/using-schemas.html) to validate the config.

E.g.
```
#:schema https://raw.githubusercontent.com/kotarac/jay/refs/heads/master/toml-spec/spec/spec.generated.json

gfx-api = "Bulkan"
```

```
taplo lint
error: "Bulkan" is not one of ["OpenGl","Vulkan"]
  ┌─ /home/kotarac/etc/.config/jay/config.toml:3:11
  │
3 │ gfx-api = "Bulkan"
  │           ^^^^^^^^ "Bulkan" is not one of ["OpenGl","Vulkan"]
```