### PR TITLE
theme: add bar-position setting

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -25,7 +25,7 @@ use {
         },
         logging::LogLevel,
         tasks::{JoinHandle, JoinSlot},
-        theme::{Color, colors::Colorable, sized::Resizable},
+        theme::{BarPosition, Color, colors::Colorable, sized::Resizable},
         timer::Timer,
         video::{
             BlendSpace, ColorSpace, Connector, DrmDevice, Eotf, Format, GfxApi, Mode, TearingMode,
@@ -1014,6 +1014,16 @@ impl ConfigClient {
         let res = self.send_with_response(&ClientMessage::GetShowTitles);
         get_response!(res, true, GetShowTitles { show });
         show
+    }
+
+    pub fn set_bar_position(&self, position: BarPosition) {
+        self.send(&ClientMessage::SetBarPosition { position });
+    }
+
+    pub fn get_bar_position(&self) -> BarPosition {
+        let res = self.send_with_response(&ClientMessage::GetBarPosition);
+        get_response!(res, BarPosition::Top, GetBarPosition { position });
+        position
     }
 
     pub fn set_middle_click_paste_enabled(&self, enabled: bool) {

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -9,7 +9,7 @@ use {
         },
         keyboard::{Keymap, mods::Modifiers, syms::KeySym},
         logging::LogLevel,
-        theme::{Color, colors::Colorable, sized::Resizable},
+        theme::{BarPosition, Color, colors::Colorable, sized::Resizable},
         timer::Timer,
         video::{
             BlendSpace, ColorSpace, Connector, DrmDevice, Eotf, Format, GfxApi, TearingMode,
@@ -812,6 +812,10 @@ pub enum ClientMessage<'a> {
         connector: Connector,
         direction: Direction,
     },
+    SetBarPosition {
+        position: BarPosition,
+    },
+    GetBarPosition,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -1055,6 +1059,9 @@ pub enum Response {
     },
     GetConnectorInDirection {
         connector: Connector,
+    },
+    GetBarPosition {
+        position: BarPosition,
     },
 }
 

--- a/jay-config/src/theme.rs
+++ b/jay-config/src/theme.rs
@@ -177,6 +177,26 @@ pub fn reset_font() {
     get!().reset_font()
 }
 
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum BarPosition {
+    #[default]
+    Top,
+    Bottom,
+}
+
+/// Sets the position of the bar.
+///
+/// Default: `Top`.
+pub fn set_bar_position(position: BarPosition) {
+    get!().set_bar_position(position);
+}
+
+/// Gets the position of the bar.
+pub fn get_bar_position() -> BarPosition {
+    get!(BarPosition::Top).get_bar_position()
+}
+
 /// Elements of the compositor whose color can be changed.
 pub mod colors {
     use {

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -67,7 +67,7 @@ use {
         },
         keyboard::{Keymap, mods::Modifiers, syms::KeySym},
         logging::LogLevel,
-        theme::{colors::Colorable, sized::Resizable},
+        theme::{BarPosition, colors::Colorable, sized::Resizable},
         timer::Timer as JayTimer,
         video::{
             BlendSpace as ConfigBlendSpace, ColorSpace, Connector, DrmDevice, Eotf as ConfigEotf,
@@ -1389,6 +1389,17 @@ impl ConfigProxyHandler {
     fn handle_get_show_titles(&self) {
         self.respond(Response::GetShowTitles {
             show: self.state.theme.show_titles.get(),
+        });
+    }
+
+    fn handle_set_bar_position(&self, position: BarPosition) {
+        self.state.theme.bar_position.set(position);
+        self.spaces_change();
+    }
+
+    fn handle_get_bar_position(&self) {
+        self.respond(Response::GetBarPosition {
+            position: self.state.theme.bar_position.get(),
         });
     }
 
@@ -3236,6 +3247,8 @@ impl ConfigProxyHandler {
             ClientMessage::GetShowBar => self.handle_get_show_bar(),
             ClientMessage::SetShowTitles { show } => self.handle_set_show_titles(show),
             ClientMessage::GetShowTitles => self.handle_get_show_titles(),
+            ClientMessage::SetBarPosition { position } => self.handle_set_bar_position(position),
+            ClientMessage::GetBarPosition => self.handle_get_bar_position(),
             ClientMessage::SeatFocusHistory { seat, timeline } => self
                 .handle_seat_focus_history(seat, timeline)
                 .wrn("seat_focus_history")?,

--- a/src/ifs/wl_surface/tray.rs
+++ b/src/ifs/wl_surface/tray.rs
@@ -135,7 +135,6 @@ impl<T: TrayItem> DynTrayItem for T {
 }
 
 trait TrayItem: Sized + 'static {
-    fn send_initial_configure(&self);
     fn send_current_configure(&self);
     fn data(&self) -> &TrayItemData;
     fn popups(&self) -> &CopyHashMap<XdgPopupId, Rc<Popup<Self>>>;
@@ -353,7 +352,7 @@ fn install<T: TrayItem>(item: &Rc<T>) -> Result<(), TrayItemError> {
     if let Some(node) = data.output.node() {
         data.surface
             .set_output(&node, NodeLocation::Output(node.id));
-        item.send_initial_configure();
+        item.send_current_configure();
     }
     Ok(())
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -139,6 +139,8 @@ impl Renderer<'_> {
                         self.state.color_manager.srgb_gamma22(),
                     );
                 }
+                x += bar_rect.x1() - non_exclusive_rect_rel.x1();
+                y += bar_rect.y1() - non_exclusive_rect_rel.y1();
                 if let Some(status) = &rd.status
                     && let Some(texture) = status.tex.texture()
                 {
@@ -159,16 +161,12 @@ impl Renderer<'_> {
                         srgb_srgb,
                     );
                 }
-                {
-                    x += bar_rect.x1() - non_exclusive_rect_rel.x1();
-                    y += bar_rect.y1() - non_exclusive_rect_rel.y1();
-                    for item in output.tray_items.iter() {
-                        let data = item.data();
-                        if data.surface.buffer.is_some() {
-                            let rect = data.rel_pos.get().move_(x, y);
-                            let bounds = self.base.scale_rect(rect);
-                            self.render_surface(&data.surface, rect.x1(), rect.y1(), Some(&bounds));
-                        }
+                for item in output.tray_items.iter() {
+                    let data = item.data();
+                    if data.surface.buffer.is_some() {
+                        let rect = data.rel_pos.get().move_(x, y);
+                        let bounds = self.base.scale_rect(rect);
+                        self.render_surface(&data.surface, rect.x1(), rect.y1(), Some(&bounds));
                     }
                 }
             }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,6 +5,7 @@ use {
         cmm::cmm_eotf::{Eotf, bt1886_eotf_args, bt1886_inv_eotf_args},
         utils::clonecell::CloneCell,
     },
+    jay_config::theme::BarPosition,
     num_traits::Float,
     std::{cell::Cell, cmp::Ordering, ops::Mul, sync::Arc},
 };
@@ -467,6 +468,7 @@ pub struct Theme {
     pub title_font: CloneCell<Option<Arc<String>>>,
     pub default_font: Arc<String>,
     pub show_titles: Cell<bool>,
+    pub bar_position: Cell<BarPosition>,
 }
 
 impl Default for Theme {
@@ -480,6 +482,7 @@ impl Default for Theme {
             title_font: Default::default(),
             default_font,
             show_titles: Cell::new(true),
+            bar_position: Default::default(),
         }
     }
 }

--- a/src/tree/output.rs
+++ b/src/tree/output.rs
@@ -66,6 +66,7 @@ use {
     },
     ahash::AHashMap,
     jay_config::{
+        theme::BarPosition,
         video::{TearingMode as ConfigTearingMode, Transform, VrrMode as ConfigVrrMode},
         workspace::WorkspaceDisplayOrder,
     },
@@ -807,11 +808,23 @@ impl OutputNode {
         let mut workspace_rect_rel = non_exclusive_rect_rel;
         if self.state.show_bar.get() {
             let underline_rect;
-            bar_rect = Rect::new_sized_unchecked(x1, y1, width, bh);
-            underline_rect = Rect::new_sized_unchecked(x1, y1 + bh, width, 1);
-            bar_rect_with_underline = Rect::new_sized_unchecked(x1, y1, width, bh + 1);
-            workspace_rect =
-                Rect::new_sized_unchecked(x1, y1 + bh + 1, width, (height - bh - 1).max(0));
+            match self.state.theme.bar_position.get() {
+                BarPosition::Bottom => {
+                    workspace_rect =
+                        Rect::new_sized_unchecked(x1, y1, width, (height - bh - 1).max(0));
+                    bar_rect_with_underline =
+                        Rect::new_sized_unchecked(x1, y1 + height - bh - 1, width, bh + 1);
+                    underline_rect = Rect::new_sized_unchecked(x1, y1 + height - bh - 1, width, 1);
+                    bar_rect = Rect::new_sized_unchecked(x1, y1 + height - bh, width, bh);
+                }
+                BarPosition::Top | _ => {
+                    bar_rect = Rect::new_sized_unchecked(x1, y1, width, bh);
+                    underline_rect = Rect::new_sized_unchecked(x1, y1 + bh, width, 1);
+                    bar_rect_with_underline = Rect::new_sized_unchecked(x1, y1, width, bh + 1);
+                    workspace_rect =
+                        Rect::new_sized_unchecked(x1, y1 + bh + 1, width, (height - bh - 1).max(0));
+                }
+            }
             bar_rect_rel = bar_rect.move_(-rect.x1(), -rect.y1());
             underline_rect_rel = underline_rect.move_(-rect.x1(), -rect.y1());
             workspace_rect_rel = workspace_rect.move_(-rect.x1(), -rect.y1());

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -33,7 +33,7 @@ use {
         keyboard::{Keymap, ModifiedKeySym, mods::Modifiers, syms::KeySym},
         logging::LogLevel,
         status::MessageFormat,
-        theme::Color,
+        theme::{BarPosition, Color},
         video::{BlendSpace, ColorSpace, Eotf, Format, GfxApi, TearingMode, Transform, VrrMode},
         window::{ContentType, TileState, WindowType},
         workspace::WorkspaceDisplayOrder,
@@ -208,6 +208,7 @@ pub struct Theme {
     pub font: Option<String>,
     pub title_font: Option<String>,
     pub bar_font: Option<String>,
+    pub bar_position: Option<BarPosition>,
 }
 
 #[derive(Debug, Clone)]

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -43,7 +43,10 @@ use {
         status::{set_i3bar_separator, set_status, set_status_command, unset_status_command},
         switch_to_vt,
         tasks::{self, JoinHandle},
-        theme::{reset_colors, reset_font, reset_sizes, set_bar_font, set_font, set_title_font},
+        theme::{
+            reset_colors, reset_font, reset_sizes, set_bar_font, set_bar_position, set_font,
+            set_title_font,
+        },
         toggle_float_above_fullscreen, toggle_show_bar, toggle_show_titles,
         video::{
             ColorSpace, Connector, DrmDevice, Eotf, connectors, drm_devices,
@@ -1597,6 +1600,9 @@ fn load_config(initial_load: bool, auto_reload: bool, persistent: &Rc<Persistent
     }
     if let Some(v) = config.show_titles {
         set_show_titles(v);
+    }
+    if let Some(v) = config.theme.bar_position {
+        set_bar_position(v);
     }
     if let Some(v) = config.focus_history {
         if let Some(v) = v.only_visible {

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -579,6 +579,14 @@
         }
       ]
     },
+    "BarPosition": {
+      "type": "string",
+      "description": "The position of the bar.",
+      "enum": [
+        "top",
+        "bottom"
+      ]
+    },
     "BlendSpace": {
       "type": "string",
       "description": "A color blend space.\n",
@@ -1999,6 +2007,10 @@
           "type": "integer",
           "description": "The height of the bar. Defaults to the title-height if not set.",
           "minimum": 0.0
+        },
+        "bar-position": {
+          "description": "The position of the bar. Defaults to `top` if not set.",
+          "$ref": "#/$defs/BarPosition"
         },
         "font": {
           "type": "string",

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -841,6 +841,25 @@ This table is a tagged union. The variant is determined by the `type` field. It 
     The value of this field should be a string.
 
 
+<a name="types-BarPosition"></a>
+### `BarPosition`
+
+The position of the bar.
+
+Values of this type should be strings.
+
+The string should have one of the following values:
+
+- `top`:
+
+  The bar is at the top of the output.
+
+- `bottom`:
+
+  The bar is at the bottom of the output.
+
+
+
 <a name="types-BlendSpace"></a>
 ### `BlendSpace`
 
@@ -4551,6 +4570,12 @@ The table has the following fields:
   The numbers should be integers.
 
   The numbers should be greater than or equal to 0.
+
+- `bar-position` (optional):
+
+  The position of the bar. Defaults to `top` if not set.
+
+  The value of this field should be a [BarPosition](#types-BarPosition).
 
 - `font` (optional):
 

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -2224,6 +2224,10 @@ Theme:
       minimum: 0
       required: false
       description: The height of the bar. Defaults to the title-height if not set.
+    bar-position:
+      ref: BarPosition
+      required: false
+      description: The position of the bar. Defaults to `top` if not set.
     font:
       kind: string
       required: false
@@ -4311,3 +4315,13 @@ SimpleIm:
         
         Even if the input method is enabled, it will only be used if there is no
         running external IM.
+
+
+BarPosition:
+  kind: string
+  description: The position of the bar.
+  values:
+    - value: top
+      description: The bar is at the top of the output.
+    - value: bottom
+      description: The bar is at the bottom of the output.


### PR DESCRIPTION
Opted for an enum in case anyone ever decides to add left / right as bar positions.

`Theme` seemed like the most appropriate place to put it in the config as there's already a couple of bar related settings there, while `Status` seemed mostly oriented towards formatting.

Tested against both `WorkspaceDisplayOrder` options to make sure dragging workspaces in `manual` works correctly.

I'm also thinking about adding a setting for hiding the underline (should perhaps rename it now), but probably better to address that separately.