### PR TITLE
it: suppress logger reinit panic

### DIFF
--- a/src/it/test_logger.rs
+++ b/src/it/test_logger.rs
@@ -18,7 +18,7 @@ thread_local! {
 }
 
 pub fn install() {
-    log::set_logger(&Logger).unwrap();
+    let _ = log::set_logger(&Logger);
     log::set_max_level(LevelFilter::Info);
 }
 


### PR DESCRIPTION
Would this make sense?

It enables running all tests, including integration, together by running `cargo test -F it`.