### PR TITLE
Add scroll accumulator for seats below version 8

### DIFF
--- a/src/ifs/wl_seat/event_handling.rs
+++ b/src/ifs/wl_seat/event_handling.rs
@@ -1476,8 +1476,11 @@ impl WlSeatGlobal {
                     }
                     p.send_axis(time, axis, delta);
                 }
-                if p.seat.version >= AXIS_STOP_SINCE_VERSION && event.stop[i].get() {
-                    p.send_axis_stop(time, axis);
+                if event.stop[i].get() {
+                    if p.seat.version >= AXIS_STOP_SINCE_VERSION {
+                        p.send_axis_stop(time, axis);
+                    }
+                    p.v120_accumulator[i].set(0);
                 }
             }
             if p.seat.version >= POINTER_FRAME_SINCE_VERSION {

--- a/src/ifs/wl_seat/wl_pointer.rs
+++ b/src/ifs/wl_seat/wl_pointer.rs
@@ -90,6 +90,9 @@ impl WlPointer {
 
     pub fn send_enter(&self, serial: u64, surface: WlSurfaceId, mut x: Fixed, mut y: Fixed) {
         self.last_motion.set((x, y));
+        for accumulator in &self.v120_accumulator {
+            accumulator.set(0);
+        }
         logical_to_client_wire_scale!(self.seat.client, x, y);
         self.seat.client.event(Enter {
             self_id: self.id,


### PR DESCRIPTION
Sorry for making so many PRs/issues when you're on holiday! Take your time to review.

Wine binds to wl_seat version 5, which does not have support for `axis_value120`, instead using `axis_discrete`. My mouse emits events whose value120 is 15/-15. The division means that it always gets clamped to 0, meaning the scroll event gets "eaten", and I cannot scroll in Wine apps/games.

https://gitlab.winehq.org/wine/wine/-/blob/ca1a99f22adca7aaf4eab7bec10f7a3bc8c62314/dlls/winewayland.drv/wayland.c#L143-144

The "proper" fix would probably be for Wine to implement support for `axis_value120`, especially as it's a bit janky now with the threshold of when the accumulator ticks over is rather arbitrary, but this at least makes apps with a wl_seat version of 5, 6, or 7 vaguely functional.