### PR TITLE
cli: always show flip margin

### DIFF
--- a/src/cli/randr.rs
+++ b/src/cli/randr.rs
@@ -1023,12 +1023,10 @@ impl Randr {
             println!("        transform: {}", name);
         }
         if let Some(flip_margin_ns) = o.flip_margin_ns {
-            if flip_margin_ns != 1_500_000 {
-                println!(
-                    "        flip margin: {:?}",
-                    Duration::from_nanos(flip_margin_ns)
-                );
-            }
+            println!(
+                "        flip margin: {:?}",
+                Duration::from_nanos(flip_margin_ns)
+            );
         }
         if o.supported_color_spaces.is_not_empty() {
             println!("        color spaces:");


### PR DESCRIPTION
Usually, it prints current dynamic flip margin when doing `jay randr` even if `flip-margin-ms` isn't set on a `DrmDevice`.
If/when it reaches the minimum of 1.5ms, it doesn't show it which seemed weird. I'd expect it to either:
1. show all the time
2. show all the time when `flip-margin-ms` is set to something
3. never show

Not sure if you might have meant to do 2, which would be more similar to some other things printed with `jay randr`.

This is, of course, totally unimportant (more text than code), but it had me surprised when I randomly noticed a line missing couple of times when doing `jay randr`.