### PR TITLE
Revert pull request #708

### DIFF
--- a/src/ifs/wl_seat/event_handling.rs
+++ b/src/ifs/wl_seat/event_handling.rs
@@ -1459,11 +1459,7 @@ impl WlSeatGlobal {
                     if p.seat.version >= AXIS_VALUE120_SINCE_VERSION {
                         p.send_axis_value120(axis, delta);
                     } else if p.seat.version >= AXIS_DISCRETE_SINCE_VERSION {
-                        let mut accumulator = p.v120_accumulator[i].get();
-                        accumulator += delta;
-                        p.send_axis_discrete(axis, accumulator / AXIS_120);
-                        accumulator %= AXIS_120;
-                        p.v120_accumulator[i].set(accumulator);
+                        p.send_axis_discrete(axis, delta / AXIS_120);
                     }
                 }
                 if let Some(delta) = event.px[i].get() {
@@ -1476,11 +1472,8 @@ impl WlSeatGlobal {
                     }
                     p.send_axis(time, axis, delta);
                 }
-                if event.stop[i].get() {
-                    if p.seat.version >= AXIS_STOP_SINCE_VERSION {
-                        p.send_axis_stop(time, axis);
-                    }
-                    p.v120_accumulator[i].set(0);
+                if p.seat.version >= AXIS_STOP_SINCE_VERSION && event.stop[i].get() {
+                    p.send_axis_stop(time, axis);
                 }
             }
             if p.seat.version >= POINTER_FRAME_SINCE_VERSION {

--- a/src/ifs/wl_seat/wl_pointer.rs
+++ b/src/ifs/wl_seat/wl_pointer.rs
@@ -74,7 +74,6 @@ pub struct WlPointer {
     pub seat: Rc<WlSeat>,
     pub tracker: Tracker<Self>,
     last_motion: Cell<(Fixed, Fixed)>,
-    pub v120_accumulator: [Cell<i32>; 2],
 }
 
 impl WlPointer {
@@ -84,15 +83,11 @@ impl WlPointer {
             seat: seat.clone(),
             tracker: Default::default(),
             last_motion: Default::default(),
-            v120_accumulator: Default::default(),
         }
     }
 
     pub fn send_enter(&self, serial: u64, surface: WlSurfaceId, mut x: Fixed, mut y: Fixed) {
         self.last_motion.set((x, y));
-        for accumulator in &self.v120_accumulator {
-            accumulator.set(0);
-        }
         logical_to_client_wire_scale!(self.seat.client, x, y);
         self.seat.client.event(Enter {
             self_id: self.id,


### PR DESCRIPTION
As discussed in https://github.com/mahkoh/jay/pull/708 the behavior in that PR is against spec.

I think, but I'm not actually sure, that the behavior before 708 is _also_ against spec, though: when `delta` is not a multiple of `AXIS_120`,

> This event does not occur on its own, it is coupled with a wl_pointer.axis event that represents this axis value on a continuous scale.

is not upheld, due to rounding towards zero.

I don't have time right now to figure out a "proper" fix (maybe sometime in the next few days), but, here's a revert!