### PR TITLE
config: add XWayland enabled option

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -1182,6 +1182,10 @@ impl ConfigClient {
         self.send(&ClientMessage::SetXScalingMode { mode })
     }
 
+    pub fn set_x_wayland_enabled(&self, enabled: bool) {
+        self.send(&ClientMessage::SetXWaylandEnabled { enabled })
+    }
+
     pub fn set_vrr_mode(&self, connector: Option<Connector>, mode: VrrMode) {
         self.send(&ClientMessage::SetVrrMode { connector, mode })
     }

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -831,6 +831,9 @@ pub enum ClientMessage<'a> {
         seat: Seat,
         mode: FallbackOutputMode,
     },
+    SetXWaylandEnabled {
+        enabled: bool,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/jay-config/src/xwayland.rs
+++ b/jay-config/src/xwayland.rs
@@ -2,6 +2,13 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Sets whether Xwayland is enabled
+///
+/// The default is `true`.
+pub fn set_x_wayland_enabled(enabled: bool) {
+    get!().set_x_wayland_enabled(enabled)
+}
+
 /// The scaling mode of X windows.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
 pub struct XScalingMode(pub u32);

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -269,6 +269,7 @@ fn start_compositor2(
         run_args,
         xwayland: XWaylandState {
             enabled: Cell::new(true),
+            running: Cell::new(false),
             pidfd: Default::default(),
             handler: Default::default(),
             queue: Default::default(),

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -979,6 +979,11 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
+    fn handle_set_x_wayland_enabled(&self, enabled: bool) -> Result<(), CphError> {
+        self.state.set_xwayland_enabled(enabled);
+        Ok(())
+    }
+
     fn handle_set_ui_drag_enabled(&self, enabled: bool) {
         self.state.ui_drag_enabled.set(enabled);
     }
@@ -3369,6 +3374,9 @@ impl ConfigProxyHandler {
             ClientMessage::SetFallbackOutputMode { seat, mode } => self
                 .handle_set_fallback_output_mode(seat, mode)
                 .wrn("set_fallback_output_mode")?,
+            ClientMessage::SetXWaylandEnabled { enabled } => self
+                .handle_set_x_wayland_enabled(enabled)
+                .wrn("set_x_wayland_enabled")?,
         }
         Ok(())
     }

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -463,6 +463,7 @@ pub struct SimpleIm {
 
 #[derive(Debug, Clone)]
 pub struct Xwayland {
+    pub enabled: Option<bool>,
     pub scaling_mode: Option<XScalingMode>,
 }
 

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -56,7 +56,7 @@ use {
         },
         window::Window,
         workspace::set_workspace_display_order,
-        xwayland::set_x_scaling_mode,
+        xwayland::{set_x_scaling_mode, set_x_wayland_enabled},
     },
     run_on_drop::on_drop,
     std::{
@@ -1578,10 +1578,13 @@ fn load_config(initial_load: bool, auto_reload: bool, persistent: &Rc<Persistent
     if let Some(threshold) = config.ui_drag.threshold {
         set_ui_drag_threshold(threshold);
     }
-    if let Some(xwayland) = config.xwayland
-        && let Some(mode) = xwayland.scaling_mode
-    {
-        set_x_scaling_mode(mode);
+    if let Some(xwayland) = config.xwayland {
+        if let Some(enabled) = xwayland.enabled {
+            set_x_wayland_enabled(enabled);
+        }
+        if let Some(mode) = xwayland.scaling_mode {
+            set_x_scaling_mode(mode);
+        }
     }
     if let Some(cm) = config.color_management
         && let Some(enabled) = cm.enabled

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -2349,6 +2349,10 @@
       "description": "Describes Xwayland settings.\n\n- Example:\n\n  ```toml\n  xwayland = { scaling-mode = \"downscaled\" }\n  ```\n",
       "type": "object",
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enables or disables XWayland.\n\nThe default is `true`.\n"
+        },
         "scaling-mode": {
           "description": "The scaling mode of X windows.",
           "$ref": "#/$defs/XScalingMode"

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -5319,6 +5319,14 @@ Values of this type should be tables.
 
 The table has the following fields:
 
+- `enabled` (optional):
+
+  Enables or disables XWayland.
+  
+  The default is `true`.
+
+  The value of this field should be a boolean.
+
 - `scaling-mode` (optional):
 
   The scaling mode of X windows.

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -3428,6 +3428,13 @@ Xwayland:
       xwayland = { scaling-mode = "downscaled" }
       ```
   fields:
+    enabled:
+      kind: boolean
+      required: false
+      description: |
+        Enables or disables XWayland.
+        
+        The default is `true`.
     scaling-mode:
       ref: XScalingMode
       required: false


### PR DESCRIPTION
I don't use any apps that require XWayland, and don't have XWayland installed. Jay still sets DISPLAY and attempts to exec XWayland and fails every time a client tries to connect. Add an option to disable it at startup! :sparkles:

For comparison against other compositors: [Hyprland supports disabling XWayland at runtime even if already started](https://github.com/hyprwm/Hyprland/blob/661314e13487784c94b3c9fd69b469764eb6ef7b/src/xwayland/XWayland.cpp#L10-L16). [Sway does not](https://github.com/swaywm/sway/blob/fa497964fd55632beacf5f425e964ae4893e25b9/sway/commands/xwayland.c#L26-L27).