### PR TITLE
fix subsurface recreation frame callback deadlock

### DIFF
--- a/src/ifs/wl_surface/wl_subsurface.rs
+++ b/src/ifs/wl_surface/wl_subsurface.rs
@@ -191,6 +191,13 @@ impl WlSubsurface {
         self.surface.set_absolute_position(x, y);
         self.surface
             .set_output(&self.parent.output.get(), self.parent.location.get());
+
+        let has_buffer = self.surface.buffer.is_some();
+        self.had_buffer.set(has_buffer);
+        if has_buffer && self.parent.visible.get() {
+            self.surface.set_visible(true);
+            self.damage();
+        }
         Ok(())
     }
 


### PR DESCRIPTION
If the surface already has a buffer (e.g. subsurface was destroyed and recreated by a nested compositor like waywall by toggling floating window visibility within the compositor), sync the `had_buffer state` and restore visibility. Without this, frame callbacks are never delivered because `set_visible(true)` is only called from `after_apply_commit()` which requires a new commit, but clients won't commit without first having a frame callback.

patch has been tested by 2 people, both verified it fixed the issue without causing any other seperate issues to arise.
@BurAndBy
@Ktrompfl

[0001-feat-fix-subsurface-recreation-frame-callback-deadlo.patch](https://github.com/user-attachments/files/25957287/0001-feat-fix-subsurface-recreation-frame-callback-deadlo.patch)
