### PR TITLE
Update Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,15 @@
             vulkan-loader
           ];
 
+          checkFlags = [
+            # the following tests require access to io_uring, which is disabled in the sandboxed build environment
+            "--skip=cpu_worker::tests::cancel"
+            "--skip=cpu_worker::tests::complete"
+            "--skip=eventfd_cache::tests::test"
+            "--skip=io_uring::ops::read_write_no_cancel::tests::cancel_in_kernel"
+            "--skip=io_uring::ops::read_write_no_cancel::tests::cancel_in_userspace"
+          ];
+
           postInstall = ''
             install -D etc/jay.portal $out/share/xdg-desktop-portal/portals/jay.portal
             install -D etc/jay-portals.conf $out/share/xdg-desktop-portal/jay-portals.conf

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
       jay-package =
         {
           lib,
+          stdenv,
           rustPlatform,
           fetchFromGitHub,
           libGL,
@@ -28,9 +29,10 @@
           libglvnd,
           vulkan-loader,
           autoPatchelfHook,
+          installShellFiles,
         }:
 
-        rustPlatform.buildRustPackage rec {
+        rustPlatform.buildRustPackage {
           pname = "jay";
           version = self.shortRev or self.dirtyShortRev or "unknown";
 
@@ -52,6 +54,7 @@
               ./wire-ei
               ./wire-to-xml
               ./wire-xcon
+              ./xml-to-wire
             ];
           };
 
@@ -61,6 +64,7 @@
 
           nativeBuildInputs = [
             autoPatchelfHook
+            installShellFiles
             pkgconf
           ];
 
@@ -82,7 +86,18 @@
           postInstall = ''
             install -D etc/jay.portal $out/share/xdg-desktop-portal/portals/jay.portal
             install -D etc/jay-portals.conf $out/share/xdg-desktop-portal/jay-portals.conf
+            install -D etc/jay.desktop $out/share/wayland-sessions/jay.desktop
+          ''
+          + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+            installShellCompletion --cmd jay \
+              --bash <("$out/bin/jay" generate-completion bash) \
+              --zsh <("$out/bin/jay" generate-completion zsh) \
+              --fish <("$out/bin/jay" generate-completion fish)
           '';
+
+          passthru = {
+            providedSessions = [ "jay" ];
+          };
 
           meta = with lib; {
             description = "Wayland compositor written in Rust";


### PR DESCRIPTION
This PR makes the following changes to the recently added Nix flake:

- Adds missing build inputs that previously caused the package to fail to build with `nix build`.
- Adds the Nix lock file to the repository. This helps ensure reproducible builds and should likely be version-controlled.
- Installs shell completions and the Wayland session file as part of the package.
- Skips tests that require `io_uring` access, since this is not permitted in the sandboxed build environment. While this restriction does not appear to be always enforced by CppNix, it causes failures with other implementations such as Lix (see https://hydra.nixos.org/build/326198517/nixlog/1).