### PR TITLE
config: allow realtime config.so if owned by root:root

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           ldd --version
       - name: Install
         run: |
+          sudo apt-get update
           sudo apt-get install -y libinput-dev libgbm-dev libudev-dev libpango1.0-dev libfontconfig-dev
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -56,6 +57,7 @@ jobs:
           ldd --version
       - name: Install
         run: |
+          sudo apt-get update
           sudo apt-get install -y libinput-dev libgbm-dev libudev-dev libpango1.0-dev libfontconfig-dev
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -97,6 +99,7 @@ jobs:
           ldd --version
       - name: Install
         run: |
+          sudo apt-get update
           sudo apt-get install -y musl-dev
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -133,6 +136,7 @@ jobs:
           ldd --version
       - name: Install
         run: |
+          sudo apt-get update
           sudo apt-get install -y libinput-dev libgbm-dev libudev-dev libpango1.0-dev \
             libfontconfig-dev libvulkan1 mesa-vulkan-drivers xwayland adwaita-icon-theme
           curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -174,6 +178,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install
         run: |
+          sudo apt-get update
           sudo apt-get install -y nix
           sudo systemctl start nix-daemon.service
           sudo chown -R $(whoami) /nix

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -134,12 +134,21 @@ retains `CAP_SYS_NICE` solely for creating elevated Vulkan queues later.
 
 ### SCHED_RR and config.so
 
-`SCHED_RR` and `config.so` are mutually exclusive: running untrusted code at
-real-time priority would be a security risk. Jay enforces this as follows:
+Running untrusted code at real-time priority would be a security risk. To
+prevent this, Jay restricts which `config.so` files can be loaded when the
+scheduler has been elevated to `SCHED_RR`.
 
-- If `config.so` exists in the config directory, Jay skips the `SCHED_RR`
-  elevation (elevated Vulkan queues are still created).
-- If Jay has already elevated to `SCHED_RR`, it refuses to load `config.so`.
+A `config.so` is considered **privileged** if it is owned by `root:root` and is
+not group-writable or world-writable. Privileged config files are assumed to
+come from a trusted source (e.g. a package manager) and are always allowed.
+
+For unprivileged `config.so` files (any other ownership or with loose
+permissions), Jay enforces mutual exclusion with `SCHED_RR`:
+
+- If an unprivileged `config.so` exists in the config directory, Jay skips the
+  `SCHED_RR` elevation (elevated Vulkan queues are still created).
+- If Jay has already elevated to `SCHED_RR`, it refuses to load an unprivileged
+  `config.so`.
 
 You can also skip `SCHED_RR` explicitly by setting `JAY_NO_REALTIME=1`:
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -314,7 +314,6 @@ fn start_compositor2(
         idle_inhibitor_ids: Default::default(),
         run_toplevel,
         config_dir: config_dir(),
-        config_file_id: NumCell::new(1),
         tracker: Default::default(),
         data_offer_ids: Default::default(),
         data_source_ids: Default::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -313,10 +313,10 @@ impl ConfigProxy {
             }
             return Err(ConfigError::NotPermitted);
         }
-        let dir = match state.config_dir.as_deref() {
-            Some(d) => d,
-            _ => return Err(ConfigError::ConfigDirNotSet),
-        };
+        let dir = state
+            .config_dir
+            .as_deref()
+            .ok_or(ConfigError::ConfigDirNotSet)?;
         let file = format!("{}/{CONFIG_SO}", dir);
         unsafe { Self::from_file(&file, state) }
     }
@@ -334,10 +334,7 @@ impl ConfigProxy {
         // a library with that path loaded. To work around this, create a
         // temporary copy with an incrementing number and load the library
         // from there.
-        let xrd = match xrd() {
-            Some(x) => x,
-            _ => return Err(ConfigError::XrdNotSet),
-        };
+        let xrd = xrd().ok_or(ConfigError::XrdNotSet)?;
         let copy = format!(
             "{}/.jay_config.so.{}.{}",
             xrd,
@@ -345,21 +342,15 @@ impl ConfigProxy {
             state.config_file_id.fetch_add(1)
         );
         let _ = uapi::unlink(copy.as_str());
-        if let Err(e) = std::fs::copy(path, &copy) {
-            return Err(ConfigError::CopyConfigFile(e));
-        }
+        std::fs::copy(path, &copy).map_err(ConfigError::CopyConfigFile)?;
         let unlink = UnlinkOnDrop(&copy);
-        let lib = match unsafe { Library::new(&copy) } {
-            Ok(l) => l,
-            Err(e) => return Err(ConfigError::CouldNotLoadLibrary(e)),
-        };
-        let entry = unsafe { lib.get::<&'static ConfigEntry>(b"JAY_CONFIG_ENTRY_V1\0") };
-        let entry = match entry {
-            Ok(e) => *e,
-            Err(e) => return Err(ConfigError::LibraryDoesNotContainEntry(e)),
+        let lib = unsafe { Library::new(&copy).map_err(ConfigError::CouldNotLoadLibrary)? };
+        let entry = unsafe {
+            lib.get::<&'static ConfigEntry>(b"JAY_CONFIG_ENTRY_V1\0")
+                .map_err(ConfigError::LibraryDoesNotContainEntry)?
         };
         mem::forget(unlink);
-        Ok(Self::new(Some(lib), entry, state, Some(copy)))
+        Ok(Self::new(Some(lib), *entry, state, Some(copy)))
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ use {
         tree::{TileState, ToplevelData, ToplevelIdentifier},
         utils::{
             clonecell::CloneCell,
-            nice::{JAY_NO_REALTIME, dont_allow_config_so},
+            nice::{JAY_NO_REALTIME, dont_allow_unprivileged_config_so},
             numcell::NumCell,
             oserror::{OsError, OsErrorExt2},
             ptr_ext::PtrExt,
@@ -32,9 +32,7 @@ use {
     libloading::Library,
     std::{
         cell::Cell,
-        mem,
-        path::Path,
-        ptr,
+        mem, ptr,
         rc::Rc,
         sync::atomic::{AtomicI32, Ordering::Relaxed},
     },
@@ -318,19 +316,6 @@ impl ConfigProxy {
     }
 
     pub fn from_config_dir(state: &Rc<State>) -> Result<Self, ConfigError> {
-        if dont_allow_config_so() {
-            if have_config_so(state.config_dir.as_deref()) {
-                log::warn!("Not loading config.so because");
-                log::warn!("  1. Jay was started with CAP_SYS_NICE");
-                log::warn!("  2. Jay was not started with {}=1", JAY_NO_REALTIME);
-                log::warn!("  3. The scheduler was elevated to SCHED_RR");
-                log::warn!(
-                    "  4. Jay was not compiled with {}=1",
-                    jay_allow_realtime_config_so!(),
-                );
-            }
-            return Err(ConfigError::NotPermitted);
-        }
         let file = open_config_so(state.config_dir.as_deref())?;
         let stat = uapi::fstat(file.raw()).map_os_err(ConfigError::StatConfigSo)?;
         let file_id = Some((stat.st_dev, stat.st_ino));
@@ -338,6 +323,18 @@ impl ConfigProxy {
             && old.file_id == file_id
         {
             return Err(ConfigError::Unchanged);
+        }
+        if dont_allow_unprivileged_config_so() && is_unprivileged_config_so(&stat) {
+            log::warn!("Not loading config.so because");
+            log::warn!("  1. Jay was started with CAP_SYS_NICE");
+            log::warn!("  2. Jay was not started with {}=1", JAY_NO_REALTIME);
+            log::warn!("  3. The scheduler was elevated to SCHED_RR");
+            log::warn!("  4. config.so is not owned by root:root or world-writable");
+            log::warn!(
+                "  5. Jay was not compiled with {}=1",
+                jay_allow_realtime_config_so!(),
+            );
+            return Err(ConfigError::NotPermitted);
         }
         unsafe { Self::from_file(file, file_id, state) }
     }
@@ -403,18 +400,12 @@ pub struct InvokedShortcut {
 
 const CONFIG_SO: &str = "config.so";
 
-pub fn have_config_so(config_dir: Option<&str>) -> bool {
-    let Some(dir) = config_dir else {
-        return false;
-    };
-    let mut dir = dir.to_owned();
-    dir.push_str("/");
-    dir.push_str(CONFIG_SO);
-    Path::new(&dir).exists()
-}
-
 pub fn open_config_so(config_dir: Option<&str>) -> Result<OwnedFd, ConfigError> {
     let dir = config_dir.ok_or(ConfigError::ConfigDirNotSet)?;
     let file = format_ustr!("{}/{CONFIG_SO}", dir);
     uapi::open(&file, O_RDONLY | O_CLOEXEC, 0).map_os_err(ConfigError::OpenConfigSo)
+}
+
+pub fn is_unprivileged_config_so(stat: &c::stat) -> bool {
+    (stat.st_uid, stat.st_gid) != (0, 0) || stat.st_mode & 0o022 != 0
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,9 +14,8 @@ use {
             clonecell::CloneCell,
             nice::{JAY_NO_REALTIME, dont_allow_config_so},
             numcell::NumCell,
+            oserror::{OsError, OsErrorExt2},
             ptr_ext::PtrExt,
-            unlink_on_drop::UnlinkOnDrop,
-            xrd::xrd,
         },
     },
     bincode::Options,
@@ -31,8 +30,20 @@ use {
         window::{self},
     },
     libloading::Library,
-    std::{cell::Cell, io, mem, path::Path, ptr, rc::Rc},
+    std::{
+        cell::Cell,
+        mem,
+        path::Path,
+        ptr,
+        rc::Rc,
+        sync::atomic::{AtomicI32, Ordering::Relaxed},
+    },
     thiserror::Error,
+    uapi::{
+        OwnedFd,
+        c::{self, O_CLOEXEC, O_RDONLY},
+        format_ustr,
+    },
 };
 
 #[derive(Debug, Error)]
@@ -43,16 +54,23 @@ pub enum ConfigError {
     LibraryDoesNotContainEntry(#[source] libloading::Error),
     #[error("Could not determine the config directory")]
     ConfigDirNotSet,
-    #[error("Could not copy the config file")]
-    CopyConfigFile(#[source] io::Error),
-    #[error("XDG_RUNTIME_DIR is not set")]
-    XrdNotSet,
     #[error("Custom config.so is not permitted")]
     NotPermitted,
+    #[error("Could not open config.so")]
+    OpenConfigSo(#[source] OsError),
+    #[error("Could not stat config.so")]
+    StatConfigSo(#[source] OsError),
+    #[error("The config.so file is unchanged")]
+    Unchanged,
+    #[error("Could not dup config.so file descriptor")]
+    DupConfigFd(#[source] OsError),
 }
+
+type FileId = (c::dev_t, c::ino_t);
 
 pub struct ConfigProxy {
     handler: CloneCell<Option<Rc<ConfigProxyHandler>>>,
+    file_id: Option<FileId>,
 }
 
 impl ConfigProxy {
@@ -217,13 +235,12 @@ unsafe extern "C" fn default_client_init(
 impl ConfigProxy {
     fn new(
         lib: Option<Library>,
+        file_id: Option<FileId>,
         entry: &ConfigEntry,
         state: &Rc<State>,
-        path: Option<String>,
     ) -> Self {
         let version = entry.version.min(VERSION);
         let data = Rc::new(ConfigProxyHandler {
-            path,
             client_data: Cell::new(ptr::null()),
             dropped: Cell::new(false),
             _lib: lib,
@@ -274,6 +291,7 @@ impl ConfigProxy {
         }
         Self {
             handler: CloneCell::new(Some(data)),
+            file_id,
         }
     }
 
@@ -291,12 +309,12 @@ impl ConfigProxy {
             unref: jay_config::_private::client::unref,
             handle_msg: jay_config::_private::client::handle_msg,
         };
-        Self::new(None, &entry, state, None)
+        Self::new(None, None, &entry, state)
     }
 
     #[cfg(feature = "it")]
     pub fn for_test(state: &Rc<State>) -> Self {
-        Self::new(None, &TEST_CONFIG_ENTRY, state, None)
+        Self::new(None, None, &TEST_CONFIG_ENTRY, state)
     }
 
     pub fn from_config_dir(state: &Rc<State>) -> Result<Self, ConfigError> {
@@ -313,15 +331,22 @@ impl ConfigProxy {
             }
             return Err(ConfigError::NotPermitted);
         }
-        let dir = state
-            .config_dir
-            .as_deref()
-            .ok_or(ConfigError::ConfigDirNotSet)?;
-        let file = format!("{}/{CONFIG_SO}", dir);
-        unsafe { Self::from_file(&file, state) }
+        let file = open_config_so(state.config_dir.as_deref())?;
+        let stat = uapi::fstat(file.raw()).map_os_err(ConfigError::StatConfigSo)?;
+        let file_id = Some((stat.st_dev, stat.st_ino));
+        if let Some(old) = state.config.get()
+            && old.file_id == file_id
+        {
+            return Err(ConfigError::Unchanged);
+        }
+        unsafe { Self::from_file(file, file_id, state) }
     }
 
-    pub unsafe fn from_file(path: &str, state: &Rc<State>) -> Result<Self, ConfigError> {
+    pub unsafe fn from_file(
+        fd: OwnedFd,
+        file_id: Option<FileId>,
+        state: &Rc<State>,
+    ) -> Result<Self, ConfigError> {
         // Here we have to do a bit of a dance to support reloading. glibc will
         // never load a library twice unless it has been unloaded in between.
         // glibc identifies libraries by their file path and by their inode
@@ -331,26 +356,22 @@ impl ConfigProxy {
         // However, if the user has created a new config with a new inode, then
         // glibc will still not reload the library if we try to load it from
         // the canonical location ~/.config/jay/config.so since it already has
-        // a library with that path loaded. To work around this, create a
-        // temporary copy with an incrementing number and load the library
-        // from there.
-        let xrd = xrd().ok_or(ConfigError::XrdNotSet)?;
-        let copy = format!(
-            "{}/.jay_config.so.{}.{}",
-            xrd,
-            uapi::getpid(),
-            state.config_file_id.fetch_add(1)
-        );
-        let _ = uapi::unlink(copy.as_str());
-        std::fs::copy(path, &copy).map_err(ConfigError::CopyConfigFile)?;
-        let unlink = UnlinkOnDrop(&copy);
+        // a library with that path loaded. To work around this, we open the
+        // config.so and dlopen via /proc/self/fd/N. We use dup to ensure that N
+        // increases by at least 1 every time we try to reload. Since we increase
+        // the file descriptor limit to the maximum, N should stay below the limit.
+        static LAST_FD: AtomicI32 = AtomicI32::new(0);
+        let dup_fd = uapi::fcntl_dupfd_cloexec(fd.raw(), LAST_FD.load(Relaxed) + 1)
+            .map_os_err(ConfigError::DupConfigFd)?;
+        LAST_FD.store(dup_fd.raw(), Relaxed);
+        let copy = format!("/proc/self/fd/{}", dup_fd.raw());
         let lib = unsafe { Library::new(&copy).map_err(ConfigError::CouldNotLoadLibrary)? };
         let entry = unsafe {
             lib.get::<&'static ConfigEntry>(b"JAY_CONFIG_ENTRY_V1\0")
                 .map_err(ConfigError::LibraryDoesNotContainEntry)?
         };
-        mem::forget(unlink);
-        Ok(Self::new(Some(lib), *entry, state, Some(copy)))
+        let entry = *entry;
+        Ok(Self::new(Some(lib), file_id, entry, state))
     }
 }
 
@@ -390,4 +411,10 @@ pub fn have_config_so(config_dir: Option<&str>) -> bool {
     dir.push_str("/");
     dir.push_str(CONFIG_SO);
     Path::new(&dir).exists()
+}
+
+pub fn open_config_so(config_dir: Option<&str>) -> Result<OwnedFd, ConfigError> {
+    let dir = config_dir.ok_or(ConfigError::ConfigDirNotSet)?;
+    let file = format_ustr!("{}/{CONFIG_SO}", dir);
+    uapi::open(&file, O_RDONLY | O_CLOEXEC, 0).map_os_err(ConfigError::OpenConfigSo)
 }

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -37,7 +37,7 @@ use {
             copyhashmap::CopyHashMap,
             errorfmt::ErrorFmt,
             numcell::NumCell,
-            oserror::{OsError, OsErrorExt},
+            oserror::OsErrorExt,
             stack::Stack,
             timer::{TimerError, TimerFd},
         },
@@ -92,7 +92,6 @@ use {
 };
 
 pub(super) struct ConfigProxyHandler {
-    pub path: Option<String>,
     pub client_data: Cell<*const u8>,
     pub dropped: Cell<bool>,
     pub _lib: Option<Library>,
@@ -217,12 +216,6 @@ impl ConfigProxyHandler {
 
         self.window_matcher_leafs.clear();
         self.window_matchers.clear();
-
-        if let Some(path) = &self.path
-            && let Err(e) = uapi::unlink(path.as_str())
-        {
-            log::error!("Could not unlink {}: {}", path, ErrorFmt(OsError(e.0)));
-        }
     }
 
     pub fn send(&self, msg: &ServerMessage) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -220,7 +220,6 @@ pub struct State {
     pub serial: NumCell<u64>,
     pub run_toplevel: Rc<RunToplevel>,
     pub config_dir: Option<String>,
-    pub config_file_id: NumCell<u64>,
     pub tracker: Tracker<Self>,
     pub data_offer_ids: DataOfferIds,
     pub data_source_ids: DataSourceIds,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,7 +66,6 @@ pub mod thread_local_data;
 pub mod threshold_counter;
 pub mod timer;
 pub mod tri;
-pub mod unlink_on_drop;
 pub mod vec_ext;
 pub mod vecdeque_ext;
 pub mod vecset;

--- a/src/utils/nice.rs
+++ b/src/utils/nice.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{compositor::config_dir, config::have_config_so},
+    crate::{
+        compositor::config_dir,
+        config::{is_unprivileged_config_so, open_config_so},
+    },
     c::sched_setscheduler,
     std::{
         env, mem,
@@ -16,7 +19,11 @@ pub fn elevate_scheduler() {
     if env::var(JAY_NO_REALTIME).as_deref().unwrap_or_default() == "1" {
         return;
     }
-    if have_config_so(config_dir().as_deref()) && dont_allow_realtime_config_so() {
+    if dont_allow_realtime_config_so()
+        && let Ok(fd) = open_config_so(config_dir().as_deref())
+        && let Ok(stat) = uapi::fstat(fd.raw())
+        && is_unprivileged_config_so(&stat)
+    {
         return;
     }
     let mut param = unsafe { mem::zeroed::<sched_param>() };
@@ -35,6 +42,6 @@ fn dont_allow_realtime_config_so() -> bool {
     option_env!(jay_allow_realtime_config_so!()).unwrap_or_default() != "1"
 }
 
-pub fn dont_allow_config_so() -> bool {
+pub fn dont_allow_unprivileged_config_so() -> bool {
     did_elevate_scheduler() && dont_allow_realtime_config_so()
 }

--- a/src/utils/unlink_on_drop.rs
+++ b/src/utils/unlink_on_drop.rs
@@ -1,7 +1,0 @@
-pub struct UnlinkOnDrop<'a>(pub &'a str);
-
-impl<'a> Drop for UnlinkOnDrop<'a> {
-    fn drop(&mut self) {
-        let _ = uapi::unlink(self.0);
-    }
-}


### PR DESCRIPTION
This contains a breaking change:

Previously reloading config.so would always re-run the configuration code in the library, even if the library was unchanged. Now this is instead a no-op.

Let me know if this breaks your setup.