### PR TITLE
it: data dir in testruns

### DIFF
--- a/src/utils/data_dir.rs
+++ b/src/utils/data_dir.rs
@@ -3,6 +3,14 @@ use std::{
     sync::LazyLock,
 };
 
+#[cfg(feature = "it")]
+pub fn data_dir() -> &'static Path {
+    static DIR: LazyLock<PathBuf> =
+        LazyLock::new(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("testruns/data"));
+    &DIR
+}
+
+#[cfg(not(feature = "it"))]
 pub fn data_dir() -> &'static Path {
     static DIR: LazyLock<PathBuf> = LazyLock::new(|| {
         let Some(mut dir) = dirs::data_local_dir() else {


### PR DESCRIPTION
While there's nothing that can go wrong atm, at least from what I can see, it seems weird that session management integration tests touch `$HOME/.local/share/jay/` and share locks (not that it would ever make a diff, but still).

This doesn't split it up per test run, but that doesn't really make a difference atm.