### PR TITLE
config: support disabling outputs

### DIFF
--- a/book/src/configuration/outputs.md
+++ b/book/src/configuration/outputs.md
@@ -376,6 +376,19 @@ use-native-gamut = true
 This has no effect when the display is explicitly operating in a wide color
 space (e.g. BT.2020).
 
+## Disabling outputs
+
+Setting `enabled = false` disables an output by default:
+
+```toml
+[[outputs]]
+match.serial-number = "123456789"
+enabled = false
+```
+
+This is useful for disabling a specific display regardless of which port it is
+connected to. Disabled outputs can be re-enabled at runtime using the CLI.
+
 ## Connector configuration
 
 The `[[connectors]]` array lets you enable or disable physical display
@@ -389,6 +402,16 @@ enabled = false
 
 Connector configuration is applied when the connector is first discovered by
 the compositor, which typically happens only at startup.
+
+### Precedence
+
+Both `[[outputs]]` and `[[connectors]]` can enable or disable a display. If
+both match the same connector, the `[[outputs]]` setting takes precedence.
+
+`[[connectors]]` matches by physical port name (e.g. `eDP-1`, `HDMI-A-1`) and
+is applied when the port is first discovered. `[[outputs]]` matches by display
+identity (serial number, manufacturer, model) and is applied when the display is
+first connected, overriding any earlier connector setting.
 
 ## Lid switch (auto-disable laptop screen)
 

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -389,6 +389,7 @@ pub struct Output {
     pub brightness: Option<Option<f64>>,
     pub blend_space: Option<BlendSpace>,
     pub use_native_gamut: Option<bool>,
+    pub enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone)]

--- a/toml-config/src/config/parsers/output.rs
+++ b/toml-config/src/config/parsers/output.rs
@@ -51,7 +51,7 @@ impl Parser for OutputParser<'_> {
         let mut ext = Extractor::new(self.cx, span, table);
         let (
             (name, match_val, x, y, scale, transform, mode, vrr_val, tearing_val, format_val),
-            (color_space, eotf, brightness_val, blend_space, use_native_gamut),
+            (color_space, eotf, brightness_val, blend_space, use_native_gamut, enabled),
         ) = ext.extract((
             (
                 opt(str("name")),
@@ -71,6 +71,7 @@ impl Parser for OutputParser<'_> {
                 opt(val("brightness")),
                 recover(opt(str("blend-space"))),
                 recover(opt(bol("use-native-gamut"))),
+                recover(opt(bol("enabled"))),
             ),
         ))?;
         let transform = match transform {
@@ -210,6 +211,7 @@ impl Parser for OutputParser<'_> {
             brightness,
             blend_space,
             use_native_gamut: use_native_gamut.despan(),
+            enabled: enabled.despan(),
         })
     }
 }

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -818,6 +818,9 @@ impl ConfigConnector {
 
 impl Output {
     fn apply(&self, c: Connector) {
+        if let Some(enabled) = self.enabled {
+            c.set_enabled(enabled);
+        }
         if self.x.is_some() || self.y.is_some() {
             let (old_x, old_y) = c.position();
             c.set_position(self.x.unwrap_or(old_x), self.y.unwrap_or(old_y));

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -1195,7 +1195,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "If specified, enables or disables the connector.\n"
+          "description": "If specified, enables or disables the connector.\n\nIf the same connector is also matched by an `[[outputs]]` entry with an\n`enabled` field, the `[[outputs]]` setting takes precedence.\n"
         }
       },
       "required": [
@@ -1904,6 +1904,10 @@
         "use-native-gamut": {
           "type": "boolean",
           "description": "Configures whether the display primaries are used.\n\nBy default, Jay pretends that the display uses sRGB primaries. This is also how\nmost other systems behave. In reality, most displays use a much larger gamut. For\nexample, they advertise that they support 95% of the DCI-P3 gamut. If the display\nis interpreting colors in their native gamut, then colors will appear more\nsaturated than their specification.\n\nIf this is set to `true`, Jay assumes that the display uses the primaries\nadvertised in its EDID. This might produce more accurate colors while also\nallowing color-managed applications to use the full gamut of the display.\n\nThis setting has no effect when the display is explicitly operating in a wide\ncolor space.\n\nThe default is `false`.\n"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "If specified, enables or disables the output.\n\nIf the same connector is also matched by a `[[connectors]]` entry with an\n`enabled` field, the `[[outputs]]` setting takes precedence.\n"
         }
       },
       "required": [

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -2492,6 +2492,9 @@ The table has the following fields:
 - `enabled` (optional):
 
   If specified, enables or disables the connector.
+  
+  If the same connector is also matched by an `[[outputs]]` entry with an
+  `enabled` field, the `[[outputs]]` setting takes precedence.
 
   The value of this field should be a boolean.
 
@@ -4187,6 +4190,15 @@ The table has the following fields:
   color space.
   
   The default is `false`.
+
+  The value of this field should be a boolean.
+
+- `enabled` (optional):
+
+  If specified, enables or disables the output.
+  
+  If the same connector is also matched by a `[[connectors]]` entry with an
+  `enabled` field, the `[[outputs]]` setting takes precedence.
 
   The value of this field should be a boolean.
 

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -1306,6 +1306,9 @@ Connector:
       description: |
         If specified, enables or disables the connector.
 
+        If the same connector is also matched by an `[[outputs]]` entry with an
+        `enabled` field, the `[[outputs]]` setting takes precedence.
+
 
 DrmDeviceMatch:
   kind: variable
@@ -2251,6 +2254,14 @@ Output:
         color space.
         
         The default is `false`.
+    enabled:
+      kind: boolean
+      required: false
+      description: |
+        If specified, enables or disables the output.
+
+        If the same connector is also matched by a `[[connectors]]` entry with an
+        `enabled` field, the `[[outputs]]` setting takes precedence.
 
 
 Transform:


### PR DESCRIPTION
Useful for disabling something like a TV by default without having to keep track of which physical connector it is connected to.