### PR TITLE
opengl: use versioned SONAMEs for EGL and GLESv2

### DIFF
--- a/src/gfx_apis/gl/egl/sys.rs
+++ b/src/gfx_apis/gl/egl/sys.rs
@@ -89,7 +89,7 @@ pub const EGL_SYNC_NATIVE_FENCE_ANDROID: EGLenum = 0x3144;
 pub const EGL_SYNC_NATIVE_FENCE_FD_ANDROID: EGLint = 0x3145;
 
 dynload! {
-    EGL: Egl from "libEGL.so" {
+    EGL: Egl from "libEGL.so.1" {
         eglQueryString: unsafe fn(dpy: EGLDisplay, name: EGLint) -> *const c::c_char,
         eglGetProcAddress: unsafe fn(procname: *const c::c_char) -> *mut u8,
         eglBindAPI: unsafe fn(api: EGLenum) -> EGLBoolean,

--- a/src/gfx_apis/gl/gl/sys.rs
+++ b/src/gfx_apis/gl/gl/sys.rs
@@ -47,7 +47,7 @@ pub const GL_ONE: GLenum = 1;
 pub const GL_ONE_MINUS_SRC_ALPHA: GLenum = 0x0303;
 
 dynload! {
-    GLESV2: GlesV2 from "libGLESv2.so" {
+    GLESV2: GlesV2 from "libGLESv2.so.2" {
         glGetString: unsafe fn(name: GLenum) -> *const u8,
         glGenRenderbuffers: unsafe fn(n: GLsizei, renderbuffers: *mut GLuint),
         glRenderbufferStorage: unsafe fn(target: GLenum, format: GLenum, width: GLsizei, height: GLsizei),


### PR DESCRIPTION
This prevents runtime failure on Linux distributions where unversioned libraries are only included with the development packages.