### PR TITLE
ci: disable nix job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,6 +173,7 @@ jobs:
           path: target
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}
   nix:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
@Ktrompfl we can reenable it if you can find a way for it not to be red for weeks at a time.