### PR TITLE
docs: clarify resize, cleanup

### DIFF
--- a/book/AGENTS.md
+++ b/book/AGENTS.md
@@ -50,11 +50,6 @@ list and must be updated when adding a new chapter. Chapter-to-topic mapping:
 | `src/control_center/cc_*.rs` | Control center panes: 11 sidebar panes + `cc_window.rs` / `cc_clients.rs` detail panes + `cc_criterion.rs` shared helper. Verify field names/ordering here |
 | `toml-config/src/config/parsers/exec.rs` | Exec parser (string, array, or table forms) |
 
-### Known spec.yaml bugs
-
-- `px-per-wheel-scroll`: listed as `kind: boolean` but parser uses `fltorint`
-  (a number). Book correctly documents it as numeric.
-
 ## Critical facts
 
 1. **Config replacement.** `~/.config/jay/config.toml` replaces the entire

--- a/book/src/configuration/shortcuts.md
+++ b/book/src/configuration/shortcuts.md
@@ -552,7 +552,9 @@ affected actions are: `move-left`, `move-down`, `move-up`, `move-right`,
 `split-horizontal`, `split-vertical`, `toggle-split`, `tile-horizontal`,
 `tile-vertical`, `show-single`, `show-all`, `toggle-fullscreen`,
 `enter-fullscreen`, `exit-fullscreen`, `close`, `toggle-floating`, `float`,
-`tile`, `toggle-float-pinned`, `pin-float`, `unpin-float`, and `resize`.
+`tile`, `toggle-float-pinned`, `pin-float`, and `unpin-float`.
+
+The parameterized `resize` action also applies to the matched window.
 
 Similarly, `kill-client` applies to the matched window's client in a window
 rule, or to the matched client in a client rule.


### PR DESCRIPTION
Fixes by Lord Clankerton GPT 5.2nd.

`resize` is not a simple action.

`px-per-wheel-scroll` spec.yaml bug was fixed in #919.