### PR TITLE
ext-workspace: keep draining commit

### DIFF
--- a/src/ifs/workspace_manager/ext_workspace_manager_v1.rs
+++ b/src/ifs/workspace_manager/ext_workspace_manager_v1.rs
@@ -268,10 +268,10 @@ impl ExtWorkspaceManagerV1RequestHandler for ExtWorkspaceManagerV1 {
                 }
                 WorkspaceChange::CreateWorkspace(name, output) => {
                     if self.client.state.workspaces.contains(&name) {
-                        return Ok(());
+                        continue;
                     }
                     let Some(output) = output.node() else {
-                        return Ok(());
+                        continue;
                     };
                     output.create_normal_workspace(&name);
                 }


### PR DESCRIPTION
If a workspace already exists or an output is stale, continue processing the commit.