### PR TITLE
systemd notify support

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -46,10 +46,11 @@ use {
     std::{
         cell::{Cell, RefCell},
         collections::{HashMap, VecDeque, hash_map::Entry},
+        env,
         future::Future,
         mem,
         ops::Deref,
-        os::fd::IntoRawFd,
+        os::{fd::IntoRawFd, unix::net::UnixDatagram},
         panic::{AssertUnwindSafe, catch_unwind},
         pin::Pin,
         ptr,
@@ -2332,6 +2333,11 @@ impl ConfigClient {
                 }
             }
             ServerMessage::GraphicsInitialized => {
+                if let Ok(addr) = env::var("NOTIFY_SOCKET") {
+                    let sock = UnixDatagram::unbound().expect("TODO: handle error");
+                    sock.send_to(b"READY=1", addr).expect("TODO: handle error");
+                }
+                // TODO: Send SD_NOTIFY here.
                 if let Some(handler) = self.on_graphics_initialized.take() {
                     ignore_panic("graphics initialized", handler);
                 }

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -47,15 +47,20 @@ use {
         cell::{Cell, RefCell},
         collections::{HashMap, VecDeque, hash_map::Entry},
         env,
+        ffi::OsStr,
         future::Future,
         io, mem,
         ops::Deref,
         os::{
             fd::IntoRawFd,
             linux::net::SocketAddrExt,
-            unix::net::{SocketAddr, UnixDatagram},
+            unix::{
+                ffi::OsStrExt,
+                net::{SocketAddr, UnixDatagram},
+            },
         },
         panic::{AssertUnwindSafe, catch_unwind},
+        path::Path,
         pin::Pin,
         ptr,
         rc::Rc,
@@ -85,7 +90,7 @@ fn run_cb<T>(name: &str, cb: &Callback<T>, t: T) {
 fn send_sd_notify_if_enabled(msg: &[u8]) {
     match env::var("NOTIFY_SOCKET") {
         Ok(addr) => {
-            if let Err(e) = try_send_sd_notify(msg, addr) {
+            if let Err(e) = try_send_sd_notify(msg, addr.as_ref()) {
                 log::error!("Failed to send systemd ready notification: {e}");
             }
         }
@@ -95,8 +100,11 @@ fn send_sd_notify_if_enabled(msg: &[u8]) {
     }
 }
 
-fn try_send_sd_notify<P: AsRef<[u8]>>(msg: &[u8], path: P) -> io::Result<()> {
-    let addr = SocketAddr::from_abstract_name(path)?;
+fn try_send_sd_notify(msg: &[u8], path: &[u8]) -> io::Result<()> {
+    let addr = match path.strip_prefix(b"@") {
+        Some(abs) => SocketAddr::from_abstract_name(abs)?,
+        None => SocketAddr::from_pathname(Path::new(OsStr::from_bytes(path)))?,
+    };
     let sock = UnixDatagram::unbound()?;
     sock.send_to_addr(msg, &addr)?;
 

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -48,10 +48,11 @@ use {
         collections::{HashMap, VecDeque, hash_map::Entry},
         env,
         future::Future,
-        mem,
+        io, mem,
         ops::Deref,
         os::{fd::IntoRawFd, unix::net::UnixDatagram},
         panic::{AssertUnwindSafe, catch_unwind},
+        path::Path,
         pin::Pin,
         ptr,
         rc::Rc,
@@ -76,6 +77,26 @@ fn run_cb<T>(name: &str, cb: &Callback<T>, t: T) {
         Ok(mut cb) => ignore_panic(name, || cb(t)),
         Err(_) => log::error!("Cannot invoke {name} callback because it is already running"),
     }
+}
+
+fn send_sd_notify_if_enabled(msg: &[u8]) {
+    match env::var("NOTIFY_SOCKET") {
+        Ok(addr) => {
+            if let Err(e) = try_send_sd_notify(msg, addr) {
+                log::error!("Failed to send systemd ready notification: {e}");
+            }
+        }
+        Err(e) => {
+            log::debug!("Not sending sd notification, NOTIFY_SOCKET not readable: {e}");
+        }
+    }
+}
+
+fn try_send_sd_notify<P: AsRef<Path>>(msg: &[u8], path: P) -> io::Result<()> {
+    let sock = UnixDatagram::unbound()?;
+    sock.send_to(msg, path)?;
+
+    Ok(())
 }
 
 fn ignore_panic(name: &str, f: impl FnOnce()) {
@@ -2333,11 +2354,7 @@ impl ConfigClient {
                 }
             }
             ServerMessage::GraphicsInitialized => {
-                if let Ok(addr) = env::var("NOTIFY_SOCKET") {
-                    let sock = UnixDatagram::unbound().expect("TODO: handle error");
-                    sock.send_to(b"READY=1", addr).expect("TODO: handle error");
-                }
-                // TODO: Send SD_NOTIFY here.
+                send_sd_notify_if_enabled(b"READY=1");
                 if let Some(handler) = self.on_graphics_initialized.take() {
                     ignore_panic("graphics initialized", handler);
                 }

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -46,21 +46,11 @@ use {
     std::{
         cell::{Cell, RefCell},
         collections::{HashMap, VecDeque, hash_map::Entry},
-        env,
-        ffi::OsStr,
         future::Future,
-        io, mem,
+        mem,
         ops::Deref,
-        os::{
-            fd::IntoRawFd,
-            linux::net::SocketAddrExt,
-            unix::{
-                ffi::OsStrExt,
-                net::{SocketAddr, UnixDatagram},
-            },
-        },
+        os::fd::IntoRawFd,
         panic::{AssertUnwindSafe, catch_unwind},
-        path::Path,
         pin::Pin,
         ptr,
         rc::Rc,
@@ -85,30 +75,6 @@ fn run_cb<T>(name: &str, cb: &Callback<T>, t: T) {
         Ok(mut cb) => ignore_panic(name, || cb(t)),
         Err(_) => log::error!("Cannot invoke {name} callback because it is already running"),
     }
-}
-
-fn send_sd_notify_if_enabled(msg: &[u8]) {
-    match env::var_os("NOTIFY_SOCKET") {
-        Some(notify_socket) => {
-            if let Err(e) = try_send_sd_notify(msg, notify_socket.as_os_str()) {
-                log::error!("Failed to send systemd ready notification: {e}");
-            }
-        }
-        None => {
-            log::debug!("Not sending sd notification, NOTIFY_SOCKET not set");
-        }
-    }
-}
-
-fn try_send_sd_notify(msg: &[u8], path: &OsStr) -> io::Result<()> {
-    let addr = match path.as_bytes().strip_prefix(b"@") {
-        Some(abs) => SocketAddr::from_abstract_name(abs)?,
-        None => SocketAddr::from_pathname(Path::new(&path))?,
-    };
-    let sock = UnixDatagram::unbound()?;
-    sock.send_to_addr(msg, &addr)?;
-
-    Ok(())
 }
 
 fn ignore_panic(name: &str, f: impl FnOnce()) {
@@ -2366,7 +2332,6 @@ impl ConfigClient {
                 }
             }
             ServerMessage::GraphicsInitialized => {
-                send_sd_notify_if_enabled(b"READY=1");
                 if let Some(handler) = self.on_graphics_initialized.take() {
                     ignore_panic("graphics initialized", handler);
                 }

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -88,22 +88,22 @@ fn run_cb<T>(name: &str, cb: &Callback<T>, t: T) {
 }
 
 fn send_sd_notify_if_enabled(msg: &[u8]) {
-    match env::var("NOTIFY_SOCKET") {
-        Ok(addr) => {
-            if let Err(e) = try_send_sd_notify(msg, addr.as_ref()) {
+    match env::var_os("NOTIFY_SOCKET") {
+        Some(notify_socket) => {
+            if let Err(e) = try_send_sd_notify(msg, notify_socket.as_os_str()) {
                 log::error!("Failed to send systemd ready notification: {e}");
             }
         }
-        Err(e) => {
-            log::debug!("Not sending sd notification, NOTIFY_SOCKET not readable: {e}");
+        None => {
+            log::debug!("Not sending sd notification, NOTIFY_SOCKET not set");
         }
     }
 }
 
-fn try_send_sd_notify(msg: &[u8], path: &[u8]) -> io::Result<()> {
-    let addr = match path.strip_prefix(b"@") {
+fn try_send_sd_notify(msg: &[u8], path: &OsStr) -> io::Result<()> {
+    let addr = match path.as_bytes().strip_prefix(b"@") {
         Some(abs) => SocketAddr::from_abstract_name(abs)?,
-        None => SocketAddr::from_pathname(Path::new(OsStr::from_bytes(path)))?,
+        None => SocketAddr::from_pathname(Path::new(&path))?,
     };
     let sock = UnixDatagram::unbound()?;
     sock.send_to_addr(msg, &addr)?;

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -50,9 +50,12 @@ use {
         future::Future,
         io, mem,
         ops::Deref,
-        os::{fd::IntoRawFd, unix::net::UnixDatagram},
+        os::{
+            fd::IntoRawFd,
+            linux::net::SocketAddrExt,
+            unix::net::{SocketAddr, UnixDatagram},
+        },
         panic::{AssertUnwindSafe, catch_unwind},
-        path::Path,
         pin::Pin,
         ptr,
         rc::Rc,
@@ -92,9 +95,10 @@ fn send_sd_notify_if_enabled(msg: &[u8]) {
     }
 }
 
-fn try_send_sd_notify<P: AsRef<Path>>(msg: &[u8], path: P) -> io::Result<()> {
+fn try_send_sd_notify<P: AsRef<[u8]>>(msg: &[u8], path: P) -> io::Result<()> {
+    let addr = SocketAddr::from_abstract_name(path)?;
     let sock = UnixDatagram::unbound()?;
-    sock.send_to(msg, path)?;
+    sock.send_to_addr(msg, &addr)?;
 
     Ok(())
 }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -121,7 +121,7 @@ pub const MAX_SCALE: Scale = Scale::from_int(16);
 pub fn start_compositor(global: GlobalArgs, args: RunArgs) {
     sighand::reset_all();
     let reaper_pid = ensure_reaper();
-    let notify_socket = take_notify_socket();
+    let notify_socket = unsafe { take_notify_socket() };
     let caps = pr_caps().into_comp();
     let caps_thread = if caps.has_nice() {
         elevate_scheduler();

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -163,7 +163,15 @@ pub fn start_compositor(global: GlobalArgs, args: RunArgs) {
 
 #[cfg(feature = "it")]
 pub fn start_compositor_for_test(future: TestFuture) -> Result<(), CompositorError> {
-    let res = start_compositor2(None, None, None, RunArgs::default(), Some(future), None);
+    let res = start_compositor2(
+        None,
+        None,
+        None,
+        RunArgs::default(),
+        Some(future),
+        None,
+        None,
+    );
     leaks::log_leaked();
     res
 }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1,5 +1,8 @@
+use std::ffi::OsString;
+
 #[cfg(feature = "it")]
 use crate::it::test_backend::TestBackend;
+use crate::utils::sd_notify::take_notify_socket;
 use {
     crate::{
         acceptor::{Acceptor, AcceptorError},
@@ -118,6 +121,7 @@ pub const MAX_SCALE: Scale = Scale::from_int(16);
 pub fn start_compositor(global: GlobalArgs, args: RunArgs) {
     sighand::reset_all();
     let reaper_pid = ensure_reaper();
+    let notify_socket = take_notify_socket();
     let caps = pr_caps().into_comp();
     let caps_thread = if caps.has_nice() {
         elevate_scheduler();
@@ -144,6 +148,7 @@ pub fn start_compositor(global: GlobalArgs, args: RunArgs) {
         args,
         None,
         caps_thread,
+        notify_socket,
     );
     leaks::log_leaked();
     if let Err(e) = res {
@@ -205,6 +210,7 @@ fn start_compositor2(
     run_args: RunArgs,
     test_future: Option<TestFuture>,
     caps_thread: Option<PrCapsThread>,
+    notify_socket: Option<OsString>,
 ) -> Result<(), CompositorError> {
     let pid = uapi::getpid();
     log::info!("pid = {pid}");
@@ -244,6 +250,7 @@ fn start_compositor2(
         kb_ctx,
         backend: CloneCell::new(Rc::new(DummyBackend)),
         forker: Default::default(),
+        notify_socket,
         default_keymap: kb_keymap,
         eng: engine.clone(),
         render_ctx: Default::default(),

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -2,7 +2,6 @@ use std::ffi::OsString;
 
 #[cfg(feature = "it")]
 use crate::it::test_backend::TestBackend;
-use crate::utils::sd_notify::take_notify_socket;
 use {
     crate::{
         acceptor::{Acceptor, AcceptorError},
@@ -88,6 +87,7 @@ use {
             rc_eq::RcEq,
             refcounted::RefCounted,
             run_toplevel::RunToplevel,
+            sd_notify::take_notify_socket,
             static_text::StaticText,
             tri::Try,
         },

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1,5 +1,3 @@
-use std::ffi::OsString;
-
 #[cfg(feature = "it")]
 use crate::it::test_backend::TestBackend;
 use {
@@ -103,6 +101,7 @@ use {
     std::{
         cell::{Cell, RefCell},
         env,
+        ffi::OsString,
         future::Future,
         ops::Deref,
         rc::Rc,

--- a/src/state.rs
+++ b/src/state.rs
@@ -132,6 +132,7 @@ use {
             queue::AsyncQueue,
             refcounted::RefCounted,
             run_toplevel::RunToplevel,
+            sd_notify::send_sd_notify_if_enabled,
         },
         video::{
             Modifier,
@@ -820,10 +821,12 @@ impl State {
             {
                 self.explicit_sync_supported.set(true);
             }
-            if !self.render_ctx_ever_initialized.replace(true)
-                && let Some(config) = self.config.get()
-            {
-                config.graphics_initialized();
+            if !self.render_ctx_ever_initialized.replace(true) {
+                send_sd_notify_if_enabled(b"READY=1");
+
+                if let Some(config) = self.config.get() {
+                    config.graphics_initialized();
+                }
             }
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -132,7 +132,7 @@ use {
             queue::AsyncQueue,
             refcounted::RefCounted,
             run_toplevel::RunToplevel,
-            sd_notify::send_sd_notify_if_enabled,
+            sd_notify::send_sd_notify,
         },
         video::{
             Modifier,
@@ -154,6 +154,7 @@ use {
     linearize::StaticMap,
     std::{
         cell::{Cell, RefCell},
+        ffi::OsString,
         fmt::{Debug, Formatter},
         mem,
         ops::{Deref, DerefMut},
@@ -173,6 +174,7 @@ pub struct State {
     pub kb_ctx: KbvmContext,
     pub backend: CloneCell<Rc<dyn Backend>>,
     pub forker: CloneCell<Option<Rc<ForkerProxy>>>,
+    pub notify_socket: Option<OsString>,
     pub default_keymap: Rc<KbvmMap>,
     pub eng: Rc<AsyncEngine>,
     pub render_ctx: CloneCell<Option<Rc<dyn GfxContext>>>,
@@ -822,7 +824,9 @@ impl State {
                 self.explicit_sync_supported.set(true);
             }
             if !self.render_ctx_ever_initialized.replace(true) {
-                send_sd_notify_if_enabled(b"READY=1");
+                if let Some(ref notify_socket) = self.notify_socket {
+                    send_sd_notify(b"READY=1", notify_socket);
+                }
 
                 if let Some(config) = self.config.get() {
                     config.graphics_initialized();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -61,6 +61,7 @@ pub mod refcounted;
 pub mod reset;
 pub mod run_toplevel;
 pub mod scroller;
+pub mod sd_notify;
 pub mod send_sync_rc;
 pub mod smallmap;
 pub mod stack;

--- a/src/utils/clone3.rs
+++ b/src/utils/clone3.rs
@@ -5,13 +5,14 @@ use {
         utils::{
             errorfmt::ErrorFmt,
             oserror::OsErrorExt2,
+            pipe::{Pipe, pipe},
             process_name::set_process_name,
             sd_notify::{get_notify_socket, send_sd_notify},
         },
     },
     run_on_drop::on_drop,
     std::{env, mem::MaybeUninit, process, slice, str::FromStr},
-    uapi::{Msghdr, MsghdrMut, OwnedFd, c},
+    uapi::{Errno, Msghdr, MsghdrMut, OwnedFd, c},
 };
 
 pub enum Forked {
@@ -96,6 +97,12 @@ pub fn ensure_reaper() -> c::pid_t {
     unsafe {
         c::prctl(c::PR_SET_CHILD_SUBREAPER, 1);
     }
+
+    let main_pid_transferred = match pipe() {
+        Ok(p) => p,
+        Err(e) => fatal!("could not create signaling pipe {}", ErrorFmt(e)),
+    };
+
     let res = match fork_with_pidfd(false) {
         Ok(r) => r,
         Err(e) => {
@@ -107,6 +114,8 @@ pub fn ensure_reaper() -> c::pid_t {
         ..
     } = res
     else {
+        wait_for_pipe_close(main_pid_transferred);
+
         unsafe {
             env::set_var(REAPER_VAR, reaper_pid.to_string());
         }
@@ -120,6 +129,7 @@ pub fn ensure_reaper() -> c::pid_t {
         let main_pid_msg = format!("MAINPID={}", main_process_id);
         send_sd_notify(main_pid_msg.as_ref(), socket.as_os_str());
     }
+    drop(main_pid_transferred);
 
     drop_all_pr_caps();
     set_process_name("jay reaper");
@@ -172,4 +182,17 @@ fn recv_pidfd(socket: &OwnedFd) -> Result<OwnedFd, ForkerError> {
         return Err(ForkerError::InvalidCmsg);
     };
     Ok(OwnedFd::new(fd))
+}
+
+fn wait_for_pipe_close(pipe: Pipe<OwnedFd, OwnedFd>) {
+    drop(pipe.write);
+    let mut buf = [0u8; 8];
+
+    loop {
+        match uapi::read(pipe.read.raw(), &mut buf[..]) {
+            Ok([]) => break,
+            Ok(_) | Err(Errno(c::EINTR)) => {}
+            Err(_) => break,
+        }
+    }
 }

--- a/src/utils/clone3.rs
+++ b/src/utils/clone3.rs
@@ -3,8 +3,10 @@ use {
         forker::ForkerError,
         pr_caps::drop_all_pr_caps,
         utils::{
-            errorfmt::ErrorFmt, oserror::OsErrorExt2, process_name::set_process_name,
-            sd_notify::send_sd_notify_if_enabled,
+            errorfmt::ErrorFmt,
+            oserror::OsErrorExt2,
+            process_name::set_process_name,
+            sd_notify::{get_notify_socket, send_sd_notify, send_sd_notify_if_enabled},
         },
     },
     run_on_drop::on_drop,
@@ -111,10 +113,14 @@ pub fn ensure_reaper() -> c::pid_t {
         set_deathsig();
         return reaper_pid;
     };
-    // TODO: This is racy in theory. A fast compositor (or unlucky scheduling) could initialize
-    //       graphics before MAINPID={} is through.
-    let main_pid_msg = format!("MAINPID={}", main_process_id);
-    send_sd_notify_if_enabled(main_pid_msg.as_ref());
+
+    if let Some(socket) = get_notify_socket() {
+        // TODO: This is racy in theory. A fast compositor (or unlucky scheduling) could initialize
+        //       graphics before MAINPID={} is through.
+        let main_pid_msg = format!("MAINPID={}", main_process_id);
+        send_sd_notify(main_pid_msg.as_ref(), socket.as_os_str());
+    }
+
     drop_all_pr_caps();
     set_process_name("jay reaper");
     while let Ok((pid, status)) = uapi::wait() {

--- a/src/utils/clone3.rs
+++ b/src/utils/clone3.rs
@@ -6,7 +6,7 @@ use {
             errorfmt::ErrorFmt,
             oserror::OsErrorExt2,
             process_name::set_process_name,
-            sd_notify::{get_notify_socket, send_sd_notify, send_sd_notify_if_enabled},
+            sd_notify::{get_notify_socket, send_sd_notify},
         },
     },
     run_on_drop::on_drop,

--- a/src/utils/clone3.rs
+++ b/src/utils/clone3.rs
@@ -2,7 +2,10 @@ use {
     crate::{
         forker::ForkerError,
         pr_caps::drop_all_pr_caps,
-        utils::{errorfmt::ErrorFmt, oserror::OsErrorExt2, process_name::set_process_name},
+        utils::{
+            errorfmt::ErrorFmt, oserror::OsErrorExt2, process_name::set_process_name,
+            sd_notify::send_sd_notify_if_enabled,
+        },
     },
     run_on_drop::on_drop,
     std::{env, mem::MaybeUninit, process, slice, str::FromStr},
@@ -108,6 +111,10 @@ pub fn ensure_reaper() -> c::pid_t {
         set_deathsig();
         return reaper_pid;
     };
+    // TODO: This is racy in theory. A fast compositor (or unlucky scheduling) could initialize
+    //       graphics before MAINPID={} is through.
+    let main_pid_msg = format!("MAINPID={}", main_process_id);
+    send_sd_notify_if_enabled(main_pid_msg.as_ref());
     drop_all_pr_caps();
     set_process_name("jay reaper");
     while let Ok((pid, status)) = uapi::wait() {

--- a/src/utils/clone3.rs
+++ b/src/utils/clone3.rs
@@ -114,12 +114,12 @@ pub fn ensure_reaper() -> c::pid_t {
         ..
     } = res
     else {
-        wait_for_pipe_close(main_pid_transferred);
-
         unsafe {
             env::set_var(REAPER_VAR, reaper_pid.to_string());
         }
         set_deathsig();
+
+        wait_for_pipe_close(main_pid_transferred);
         return reaper_pid;
     };
 

--- a/src/utils/clone3.rs
+++ b/src/utils/clone3.rs
@@ -100,7 +100,7 @@ pub fn ensure_reaper() -> c::pid_t {
 
     let main_pid_transferred = match pipe() {
         Ok(p) => p,
-        Err(e) => fatal!("could not create signaling pipe {}", ErrorFmt(e)),
+        Err(e) => fatal!("Could not create signaling pipe {}", ErrorFmt(e)),
     };
 
     let res = match fork_with_pidfd(false) {

--- a/src/utils/sd_notify.rs
+++ b/src/utils/sd_notify.rs
@@ -1,0 +1,37 @@
+use std::{
+    env,
+    ffi::OsStr,
+    io,
+    os::{
+        linux::net::SocketAddrExt,
+        unix::{
+            ffi::OsStrExt,
+            net::{SocketAddr, UnixDatagram},
+        },
+    },
+    path::Path,
+};
+
+pub fn send_sd_notify_if_enabled(msg: &[u8]) {
+    match env::var_os("NOTIFY_SOCKET") {
+        Some(notify_socket) => {
+            if let Err(e) = try_send_sd_notify(msg, notify_socket.as_os_str()) {
+                log::error!("Failed to send systemd ready notification: {e}");
+            }
+        }
+        None => {
+            log::debug!("Not sending sd notification, NOTIFY_SOCKET not set");
+        }
+    }
+}
+
+fn try_send_sd_notify(msg: &[u8], path: &OsStr) -> io::Result<()> {
+    let addr = match path.as_bytes().strip_prefix(b"@") {
+        Some(abs) => SocketAddr::from_abstract_name(abs)?,
+        None => SocketAddr::from_pathname(Path::new(&path))?,
+    };
+    let sock = UnixDatagram::unbound()?;
+    sock.send_to_addr(msg, &addr)?;
+
+    Ok(())
+}

--- a/src/utils/sd_notify.rs
+++ b/src/utils/sd_notify.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    ffi::OsStr,
+    ffi::{OsStr, OsString},
     io,
     os::{
         linux::net::SocketAddrExt,
@@ -12,21 +12,27 @@ use std::{
     path::Path,
 };
 
+const NOTIFY_SOCKET: &str = "NOTIFY_SOCKET";
+
 pub fn send_sd_notify_if_enabled(msg: &[u8]) {
     match env::var_os("NOTIFY_SOCKET") {
         Some(notify_socket) => {
-            if let Err(e) = try_send_sd_notify(msg, notify_socket.as_os_str()) {
-                // TODO: This could be logging, but is eprintln! right now, while things are racy.
-                eprintln!(
-                    "Failed to send systemd notification `{}`: {e}",
-                    String::from_utf8_lossy(msg)
-                );
-            }
+            send_sd_notify(msg, notify_socket.as_os_str());
         }
         None => {
             // TODO: This could be logging, but is eprintln! right now, while things are racy.
             eprintln!("Not sending sd notification, NOTIFY_SOCKET not set");
         }
+    }
+}
+
+pub fn send_sd_notify(msg: &[u8], path: &OsStr) {
+    if let Err(e) = try_send_sd_notify(msg, path) {
+        // TODO: This could be logging, but is eprintln! right now, while things are racy.
+        eprintln!(
+            "Failed to send systemd notification `{}`: {e}",
+            String::from_utf8_lossy(msg)
+        );
     }
 }
 
@@ -39,4 +45,16 @@ fn try_send_sd_notify(msg: &[u8], path: &OsStr) -> io::Result<()> {
     sock.send_to_addr(msg, &addr)?;
 
     Ok(())
+}
+
+pub fn get_notify_socket() -> Option<OsString> {
+    env::var_os(NOTIFY_SOCKET)
+}
+
+pub fn take_notify_socket() -> Option<OsString> {
+    let notify_socket = get_notify_socket()?;
+    unsafe {
+        env::remove_var(NOTIFY_SOCKET);
+    }
+    Some(notify_socket)
 }

--- a/src/utils/sd_notify.rs
+++ b/src/utils/sd_notify.rs
@@ -14,18 +14,6 @@ use std::{
 
 const NOTIFY_SOCKET: &str = "NOTIFY_SOCKET";
 
-pub fn send_sd_notify_if_enabled(msg: &[u8]) {
-    match env::var_os("NOTIFY_SOCKET") {
-        Some(notify_socket) => {
-            send_sd_notify(msg, notify_socket.as_os_str());
-        }
-        None => {
-            // TODO: This could be logging, but is eprintln! right now, while things are racy.
-            eprintln!("Not sending sd notification, NOTIFY_SOCKET not set");
-        }
-    }
-}
-
 pub fn send_sd_notify(msg: &[u8], path: &OsStr) {
     if let Err(e) = try_send_sd_notify(msg, path) {
         // TODO: This could be logging, but is eprintln! right now, while things are racy.

--- a/src/utils/sd_notify.rs
+++ b/src/utils/sd_notify.rs
@@ -39,7 +39,7 @@ pub fn get_notify_socket() -> Option<OsString> {
     env::var_os(NOTIFY_SOCKET)
 }
 
-pub fn take_notify_socket() -> Option<OsString> {
+pub unsafe fn take_notify_socket() -> Option<OsString> {
     let notify_socket = get_notify_socket()?;
     unsafe {
         env::remove_var(NOTIFY_SOCKET);

--- a/src/utils/sd_notify.rs
+++ b/src/utils/sd_notify.rs
@@ -16,7 +16,6 @@ const NOTIFY_SOCKET: &str = "NOTIFY_SOCKET";
 
 pub fn send_sd_notify(msg: &[u8], path: &OsStr) {
     if let Err(e) = try_send_sd_notify(msg, path) {
-        // TODO: This could be logging, but is eprintln! right now, while things are racy.
         eprintln!(
             "Failed to send systemd notification `{}`: {e}",
             String::from_utf8_lossy(msg)

--- a/src/utils/sd_notify.rs
+++ b/src/utils/sd_notify.rs
@@ -16,11 +16,13 @@ pub fn send_sd_notify_if_enabled(msg: &[u8]) {
     match env::var_os("NOTIFY_SOCKET") {
         Some(notify_socket) => {
             if let Err(e) = try_send_sd_notify(msg, notify_socket.as_os_str()) {
-                log::error!("Failed to send systemd ready notification: {e}");
+                // TODO: This could be logging, but is eprintln! right now, while things are racy.
+                eprintln!("Failed to send systemd ready notification: {e}");
             }
         }
         None => {
-            log::debug!("Not sending sd notification, NOTIFY_SOCKET not set");
+            // TODO: This could be logging, but is eprintln! right now, while things are racy.
+            eprintln!("Not sending sd notification, NOTIFY_SOCKET not set");
         }
     }
 }

--- a/src/utils/sd_notify.rs
+++ b/src/utils/sd_notify.rs
@@ -17,7 +17,10 @@ pub fn send_sd_notify_if_enabled(msg: &[u8]) {
         Some(notify_socket) => {
             if let Err(e) = try_send_sd_notify(msg, notify_socket.as_os_str()) {
                 // TODO: This could be logging, but is eprintln! right now, while things are racy.
-                eprintln!("Failed to send systemd ready notification: {e}");
+                eprintln!(
+                    "Failed to send systemd notification `{}`: {e}",
+                    String::from_utf8_lossy(msg)
+                );
             }
         }
         None => {


### PR DESCRIPTION
I was trying to setup `jay` through systemd, along with other services depending on it (e.g. starting Signal through a user unit). The initial approach was simple enough, just make the Jay user service `Type=notify` and send the readiness notification manually in `on-graphics-ready`.

This comes with a catch though: Since the compositor process forks from the main (reaper) process, `NotifyAccess=all` is necessary, allowing other processes to signal readiness.

Things took an unexpected turn when I started PostgreSQL in a terminal -- after ending it, the `NOTIFY_SOCKET` envvar was still intact, it dutifully sent `STOPPING=1` down the shared(!) socket, dropping me back to the login greeter rather abruptly.

The solution would be proper systemd notify integration, here's my take on it:

1. If `NOTIFY_SOCKET` is set, after spawning the compositor, we send `MAINPID=...`, which signals systemd to treat the compositor as the main process. This allows us to keep `NotifyAccess=main`.
2. Once the compositor starts up, just before executing `on-graphics-initialized`, it sends `READY=1`, signaling systemd that it has started successfully.
3. To not confuse spawned programs, immediately after the compositor forks, we remove `NOTIFY_SOCKET` from its environment (and carry it forward).
4. To avoid the race condition where the compositor reaches graphics-ready before the reaper had a chance to send `MAINPID=...`, we install a barrier pipe and wait for it to close. Slim chance, but it would lead to a stuck service otherwise and a frustrating bug to find.

The only potential side-effect for systemd `Type=notify` users is that now the compositor instead of the reaper is considered the main process.

Happy for any feedback, if this is not a feature you want in jay, feel free to close it. I also wasn't sure about the AI policy of this project, so for now, this PR consists of free-range, organic hand-written bytes only, although an LLM was used to explain the codebase initially, which I believe is in spirit with the generated docs. I think clarification on slop tolerance for this project couldn't hurt :)