### PR TITLE
flake: update included fileset

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,25 +56,7 @@
 
           src = lib.fileset.toSource {
             root = ./.;
-            fileset = lib.fileset.unions [
-              ./algorithms
-              ./build
-              ./Cargo.lock
-              ./Cargo.toml
-              ./etc
-              ./jay-config
-              ./jay-proc
-              ./rustfmt.toml
-              ./src
-              ./toml-config
-              ./toml-spec
-              ./wire
-              ./wire-dbus
-              ./wire-ei
-              ./wire-to-xml
-              ./wire-xcon
-              ./xml-to-wire
-            ];
+            fileset = lib.fileset.gitTracked ./.;
           };
 
           cargoLock = {


### PR DESCRIPTION
Sorry to open yet another PR for the Nix flake but `codegen/` was added recently and isn't included in the flake's source fileset, which breaks the build again. 

I've changed the derivation to now include all git-tracked files so future additions are picked up automatically.   