### PR TITLE
Fix bug on `get_keyboard` without surface

### DIFF
--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -1836,14 +1836,18 @@ impl WlSeatRequestHandler for WlSeat {
         track!(self.client, p);
         self.client.add_client_obj(&p)?;
         self.keyboards.set(req.id, p.clone());
+        let kb_state = self.global.seat_kb_state.get();
+        let kb_state = kb_state.borrow();
         if let Some(surface) = self.global.keyboard_node.get().node_into_surface()
             && surface.client.id == self.client.id
         {
             p.enter(
                 self.client.next_serial(),
                 surface.id,
-                &self.global.seat_kb_state.get().borrow().kb_state,
+                &kb_state.kb_state,
             );
+        } else {
+            p.send_initial_keymap(&kb_state.kb_state);
         }
         if self.version >= REPEAT_INFO_SINCE {
             let (rate, delay) = self.global.repeat_rate.get();

--- a/src/ifs/wl_seat/wl_keyboard.rs
+++ b/src/ifs/wl_seat/wl_keyboard.rs
@@ -81,6 +81,10 @@ impl WlKeyboard {
         self.send_modifiers(serial, &kb_state.mods);
     }
 
+    pub fn send_initial_keymap(self: &Rc<Self>, state: &KeyboardState) {
+        self.send_keymap(state);
+    }
+
     fn send_keymap(self: &Rc<Self>, state: &KeyboardState) {
         let fd = match self.seat.keymap_fd(state) {
             Ok(fd) => fd,


### PR DESCRIPTION
Hello,

I was testing Jay for the first time and noticed that my terminal would hang when I tried to yank to clipboard in `helix` editor.

Launching `wl-copy` and `wl-paste` with wayland debug, I noticed the following:

`WAYLAND_DEBUG=1 wl-copy` output (truncated)

```
[ 593417.233] {Default Queue} wl_seat#10.capabilities(3)
[ 593417.241] {Default Queue} wl_seat#10.name("default")
[ 593417.262] {Default Queue} wl_callback#3.done(0)
[ 593417.269] {Default Queue}  -> wl_data_device_manager#6.get_data_device(new id wl_data_device#3, wl_seat#10)
[ 593568.306] {Default Queue}  -> wl_data_device_manager#6.create_data_source(new id wl_data_source#11)
[ 593568.327] {Default Queue}  -> wl_data_source#11.offer("text/plain")
[ 593568.334] {Default Queue}  -> wl_data_source#11.offer("text/plain")
[ 593568.339] {Default Queue}  -> wl_data_source#11.offer("text/plain;charset=utf-8")
[ 593568.346] {Default Queue}  -> wl_data_source#11.offer("TEXT")
[ 593568.370] {Default Queue}  -> wl_data_source#11.offer("STRING")
[ 593568.376] {Default Queue}  -> wl_data_source#11.offer("UTF8_STRING")
[ 593568.384] {Default Queue}  -> wl_seat#10.get_keyboard(new id wl_keyboard#12)
```

and then the process hangs.

Same with:

`WAYLAND_DEBUG=1 wl-paste` output (truncated)

```
[ 607809.706] {Default Queue} wl_seat#10.capabilities(3)
[ 607809.712] {Default Queue} wl_seat#10.name("default")
[ 607809.718] {Default Queue} wl_callback#3.done(0)
[ 607809.725] {Default Queue}  -> wl_data_device_manager#6.get_data_device(new id wl_data_device#3, wl_seat#10)
[ 607809.734] {Default Queue}  -> wl_seat#10.get_keyboard(new id wl_keyboard#11)
```

I have played a bit with compositor development in the past, and I remember I had to specifically handle `wl-copy` and `wl-paste` - they spawn a 1x1 surface. Right now, jay is actually tiling this surface and, after this fix, I see it being spawned for a split second when I launch `wl-copy` or `wl-paste` in a terminal. You might want to fix that in a separate PR.

I would also recommend taking a look at [`wlroots`](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/types/seat/wlr_seat_keyboard.c?ref_type=heads#L420). They always send the keymap, as you can check there.

I am not too comfortable with jay or even `wlroots`. Feel free to propose some other solution to this specific problem if you are not happy with the fix, I'd be glad to help.

Cheers