### PR TITLE
fix idle inhibition by decoupling from surface visibility toggles

### DIFF
--- a/src/ifs/wl_surface.rs
+++ b/src/ifs/wl_surface.rs
@@ -1807,6 +1807,10 @@ impl WlSurface {
         self.latch_listener.attach(&output.latch_event);
     }
 
+    pub fn is_visible(&self) -> bool {
+        self.visible[LiveTL].get()
+    }
+
     pub fn set_visible(self: &Rc<Self>, visible: bool) {
         let changed = self.set_visible_(visible);
         if !changed {
@@ -1822,12 +1826,8 @@ impl WlSurface {
         if visible {
             self.attach_events_to_output(&self.output.get());
         }
-        for (_, inhibitor) in &self.idle_inhibitors {
-            if visible {
-                inhibitor.activate();
-            } else {
-                inhibitor.deactivate();
-            }
+        if self.idle_inhibitors.len() > 0 {
+            self.client.state.idle.inhibitors_changed(&self.client.state);
         }
         let children = self.children.borrow_mut();
         if let Some(children) = children.deref() {
@@ -1878,9 +1878,6 @@ impl WlSurface {
     fn detach_node_(&self, set_invisible: bool) {
         for (_, constraint) in &self.constraints {
             constraint.deactivate(true);
-        }
-        for (_, inhibitor) in &self.idle_inhibitors {
-            inhibitor.deactivate();
         }
         let children = self.children.borrow();
         if let Some(ch) = children.deref() {

--- a/src/ifs/wl_surface/zwp_idle_inhibitor_v1.rs
+++ b/src/ifs/wl_surface/zwp_idle_inhibitor_v1.rs
@@ -4,7 +4,6 @@ use {
         ifs::wl_surface::WlSurface,
         leaks::Tracker,
         object::{Object, Version},
-        tree::TreeTimeline::LiveTL,
         wire::{ZwpIdleInhibitorV1Id, zwp_idle_inhibitor_v1::*},
     },
     std::rc::Rc,
@@ -37,9 +36,7 @@ impl ZwpIdleInhibitorV1RequestHandler for ZwpIdleInhibitorV1 {
 impl ZwpIdleInhibitorV1 {
     pub fn install(self: &Rc<Self>) -> Result<(), ZwpIdleInhibitorV1Error> {
         self.surface.idle_inhibitors.insert(self.id, self.clone());
-        if self.surface.visible[LiveTL].get() {
-            self.activate();
-        }
+        self.activate();
         Ok(())
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -430,7 +430,7 @@ impl IdleState {
         }
     }
 
-    fn inhibitors_changed(&self, state: &State) {
+    pub fn inhibitors_changed(&self, state: &State) {
         self.inhibitors_changed.set(true);
         self.change.trigger();
         state.trigger_cci(CCI_IDLE);

--- a/src/tasks/idle.rs
+++ b/src/tasks/idle.rs
@@ -93,7 +93,10 @@ impl Idle {
 
     fn handle_idle_changes(&mut self) {
         if self.state.idle.inhibitors_changed.replace(false) {
-            let is_inhibited = self.state.idle.inhibitors.len() > 0;
+            let is_inhibited = {
+                let inhibitors = self.state.idle.inhibitors.lock();
+                inhibitors.values().any(|i| i.surface.is_visible())
+            };
             if self.is_inhibited != is_inhibited {
                 self.is_inhibited = is_inhibited;
                 if !self.is_inhibited {


### PR DESCRIPTION
The old code synchronized inhibitors between per-surface and global maps on every visibility change via set_visible_() and detach_node_(). This was fragile: per-surface inhibitor entries disappeared during visibility toggles, leaving stale entries in the global map that could not be reactivated when the surface became visible again.

Refactor the design so inhibitors live in the global map from creation until explicit destruction or client disconnect. The idle task now evaluates surface visibility at check time rather than relying on activate/deactivate hooks on visibility changes.

- wl_surface: add is_visible() public accessor for SplitView<Cell<bool>>
- set_visible_(): replace inhibitor activate/deactivate loop with inhibitors_changed trigger so the idle task re-evaluates inhibition
- detach_node_(): remove inhibitor deactivate loop entirely
- install(): always call activate() regardless of surface visibility
- idle: check inhibitor surface visibility via is_visible() instead of testing only global map length
- state: make inhibitors_changed() public for cross-module access