### PR TITLE
metal: allow disabling flip margin adjustment

### DIFF
--- a/book/src/configuration/gpu.md
+++ b/book/src/configuration/gpu.md
@@ -197,7 +197,18 @@ flip-margin-ms = 2.0
 ```
 
 If the margin is set too small, the compositor will dynamically increase it to
-avoid missed frames.
+avoid missed frames. To keep the configured margin fixed and drop frames instead
+of increasing input latency, disable automatic adjustment:
+
+```toml
+[[drm-devices]]
+match = {
+    pci-vendor = 0x1002,
+    pci-model = 0x73ff,
+}
+flip-margin-ms = 1.0
+flip-margin-auto-adjustment = false
+```
 
 ## Explicit sync
 

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -306,7 +306,8 @@ frames. The default is 1.5 ms:
 ```
 
 If you see missed frames, try increasing it. If you want lower latency, try
-decreasing it -- Jay will dynamically increase it if the margin is too small.
+decreasing it. Jay dynamically increases a margin that is too small unless
+`flip-margin-auto-adjustment = false` is set for the DRM device.
 
 **4. Enable direct scanout:**
 

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -1099,6 +1099,17 @@ impl ConfigClient {
         self.send(&ClientMessage::SetFlipMargin { device, margin });
     }
 
+    pub fn drm_device_flip_margin_auto_adjustment_enabled(&self, device: DrmDevice) -> bool {
+        let res =
+            self.send_with_response(&ClientMessage::GetFlipMarginAutoAdjustmentEnabled { device });
+        get_response!(res, true, GetFlipMarginAutoAdjustmentEnabled { enabled });
+        enabled
+    }
+
+    pub fn set_flip_margin_auto_adjustment_enabled(&self, device: DrmDevice, enabled: bool) {
+        self.send(&ClientMessage::SetFlipMarginAutoAdjustmentEnabled { device, enabled });
+    }
+
     pub fn set_ui_drag_enabled(&self, enabled: bool) {
         self.send(&ClientMessage::SetUiDragEnabled { enabled });
     }

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -1008,6 +1008,13 @@ pub enum ClientMessage<'a> {
     GetPlaneColorPipelinesEnabled {
         device: DrmDevice,
     },
+    GetFlipMarginAutoAdjustmentEnabled {
+        device: DrmDevice,
+    },
+    SetFlipMarginAutoAdjustmentEnabled {
+        device: DrmDevice,
+        enabled: bool,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -1280,6 +1287,9 @@ pub enum Response {
         borders: ContainerBorders,
     },
     GetPlaneColorPipelinesEnabled {
+        enabled: bool,
+    },
+    GetFlipMarginAutoAdjustmentEnabled {
         enabled: bool,
     },
 }

--- a/jay-config/src/video.rs
+++ b/jay-config/src/video.rs
@@ -664,6 +664,27 @@ impl DrmDevice {
     pub fn toggle_plane_color_pipelines_enabled(self) {
         self.set_plane_color_pipelines_enabled(!self.plane_color_pipelines_enabled());
     }
+
+    /// Enables or disables automatic flip-margin adjustment.
+    ///
+    /// When enabled, the compositor dynamically increases the flip margin if it misses page
+    /// flips. When disabled, the configured margin remains fixed and frames can be dropped
+    /// instead. This is enabled by default.
+    pub fn set_flip_margin_auto_adjustment_enabled(self, enabled: bool) {
+        get!().set_flip_margin_auto_adjustment_enabled(self, enabled);
+    }
+
+    /// Returns whether automatic flip-margin adjustment is enabled.
+    pub fn flip_margin_auto_adjustment_enabled(self) -> bool {
+        get!().drm_device_flip_margin_auto_adjustment_enabled(self)
+    }
+
+    /// Toggles automatic flip-margin adjustment.
+    pub fn toggle_flip_margin_auto_adjustment_enabled(self) {
+        let get = get!();
+        let enabled = get.drm_device_flip_margin_auto_adjustment_enabled(self);
+        get.set_flip_margin_auto_adjustment_enabled(self, !enabled);
+    }
 }
 
 /// A graphics API.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -669,6 +669,12 @@ pub trait BackendDrmDevice {
     fn flip_margin(&self) -> Option<u64> {
         None
     }
+    fn set_flip_margin_auto_adjustment_enabled(&self, enabled: bool) {
+        let _ = enabled;
+    }
+    fn flip_margin_auto_adjustment_enabled(&self) -> bool {
+        true
+    }
     fn set_use_plane_color_pipelines(&self, use_plane_color_pipelines: bool) {
         let _ = use_plane_color_pipelines;
     }

--- a/src/backends/metal/video.rs
+++ b/src/backends/metal/video.rs
@@ -194,6 +194,7 @@ pub struct MetalDrmDevice {
     pub leases_to_break: CopyHashMap<MetalLeaseId, MetalLeaseData>,
     pub paused: Cell<bool>,
     pub min_post_commit_margin: Cell<u64>,
+    pub flip_margin_auto_adjustment_enabled: Cell<bool>,
     pub supports_plane_color_pipelines: bool,
     pub use_plane_color_pipelines: Cell<bool>,
     pub cm: MetalCmDevice,
@@ -211,6 +212,19 @@ impl MetalDrmDevice {
             return ctx.dev_id == self.id;
         }
         false
+    }
+
+    fn reset_flip_margin(&self) {
+        let margin = self.min_post_commit_margin.get();
+        if let Some(dd) = self.backend.device_holder.drm_devices.get(&self.devnum) {
+            for c in dd.connectors.lock().values() {
+                c.post_commit_margin.set(margin);
+                c.post_commit_margin_decay.reset(margin);
+                if let Some(output) = self.backend.state.root.outputs.get(&c.connector_id) {
+                    output.set_flip_margin(margin);
+                }
+            }
+        }
     }
 }
 
@@ -379,19 +393,22 @@ impl BackendDrmDevice for MetalDrmDevice {
 
     fn set_flip_margin(&self, margin: u64) {
         self.min_post_commit_margin.set(margin);
-        if let Some(dd) = self.backend.device_holder.drm_devices.get(&self.devnum) {
-            for c in dd.connectors.lock().values() {
-                c.post_commit_margin.set(margin);
-                c.post_commit_margin_decay.reset(margin);
-                if let Some(output) = self.backend.state.root.outputs.get(&c.connector_id) {
-                    output.set_flip_margin(margin);
-                }
-            }
-        }
+        self.reset_flip_margin();
     }
 
     fn flip_margin(&self) -> Option<u64> {
         Some(self.min_post_commit_margin.get())
+    }
+
+    fn set_flip_margin_auto_adjustment_enabled(&self, enabled: bool) {
+        self.flip_margin_auto_adjustment_enabled.set(enabled);
+        if !enabled {
+            self.reset_flip_margin();
+        }
+    }
+
+    fn flip_margin_auto_adjustment_enabled(&self) -> bool {
+        self.flip_margin_auto_adjustment_enabled.get()
     }
 
     fn set_use_plane_color_pipelines(&self, use_plane_color_pipelines: bool) {
@@ -2118,6 +2135,7 @@ impl MetalBackend {
             leases_to_break: Default::default(),
             paused: Cell::new(false),
             min_post_commit_margin: Cell::new(DEFAULT_POST_COMMIT_MARGIN),
+            flip_margin_auto_adjustment_enabled: Cell::new(true),
             supports_plane_color_pipelines,
             use_plane_color_pipelines: Cell::new(false),
             cm: MetalCmDevice::new(&vendor),
@@ -2432,6 +2450,9 @@ impl MetalBackend {
         let old_margin = connector.post_commit_margin.get();
         let new_margin = if n_missed > 0 {
             log::debug!("{}: Missed {n_missed} page flips", connector.kernel_id());
+            if !dev.dev.flip_margin_auto_adjustment_enabled.get() {
+                return;
+            }
             let refresh = dd.refresh as u64;
             if old_margin >= refresh {
                 return;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -288,3 +288,41 @@ pub fn main() {
         Cmd::Config(a) => config::main(cli.global, a),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_auto_adjustment_enabled(value: &str) -> bool {
+        let cli = Jay::try_parse_from([
+            "jay",
+            "randr",
+            "card",
+            "card0",
+            "timing",
+            "auto-adjustment",
+            value,
+        ])
+        .unwrap();
+        let Cmd::Randr(RandrArgs {
+            command:
+                Some(randr::RandrCmd::Card(randr::CardArgs {
+                    command:
+                        randr::CardCommand::Timing(randr::TimingArgs {
+                            cmd: randr::TimingCmd::AutoAdjustment(args),
+                        }),
+                    ..
+                })),
+        }) = cli.command
+        else {
+            panic!("unexpected CLI parse result");
+        };
+        args.cmd.enabled()
+    }
+
+    #[test]
+    fn parses_flip_margin_auto_adjustment() {
+        assert!(parse_auto_adjustment_enabled("enable"));
+        assert!(!parse_auto_adjustment_enabled("disable"));
+    }
+}

--- a/src/cli/json.rs
+++ b/src/cli/json.rs
@@ -120,6 +120,7 @@ pub struct JsonDrmDevice<'a> {
     pub render_device: bool,
     pub use_plane_color_pipelines: bool,
     pub plane_color_pipelines_supported: bool,
+    pub flip_margin_auto_adjustment: bool,
     #[serde(skip_serializing_if = "is_empty")]
     pub connectors: Vec<JsonConnector<'a>>,
 }

--- a/src/cli/randr.rs
+++ b/src/cli/randr.rs
@@ -113,12 +113,34 @@ pub enum TimingCmd {
     ///
     /// Note that if the margin is too small, the compositor will dynamically increase it.
     SetFlipMargin(SetFlipMarginArgs),
+    /// Modify automatic flip-margin adjustment.
+    AutoAdjustment(AutoAdjustmentArgs),
 }
 
 #[derive(Args, Debug, Clone)]
 pub struct SetFlipMarginArgs {
     /// The margin in milliseconds.
     pub margin_ms: f64,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct AutoAdjustmentArgs {
+    #[clap(subcommand)]
+    pub cmd: AutoAdjustmentCmd,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum AutoAdjustmentCmd {
+    /// Enable automatic flip-margin adjustment.
+    Enable,
+    /// Disable automatic flip-margin adjustment.
+    Disable,
+}
+
+impl AutoAdjustmentCmd {
+    pub(super) fn enabled(self) -> bool {
+        matches!(self, Self::Enable)
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -559,6 +581,7 @@ struct Device {
     pub render_device: bool,
     pub use_plane_color_pipelines: bool,
     pub plane_color_pipelines_supported: bool,
+    pub flip_margin_auto_adjustment: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -1014,6 +1037,16 @@ impl Randr {
                         margin_ns: (sfm.margin_ms * 1_000_000.0) as u64,
                     });
                 }
+                TimingCmd::AutoAdjustment(auto) => {
+                    self.handle_error(randr, |msg| {
+                        eprintln!("Could not modify automatic flip-margin adjustment: {msg}");
+                    });
+                    tc.send(jay_randr::SetFlipMarginAutoAdjustment {
+                        self_id: randr,
+                        dev: &args.card,
+                        enabled: auto.cmd.enabled() as u32,
+                    });
+                }
             },
             CardCommand::PlaneColorPipelines(ps) => {
                 self.handle_error(randr, |msg| {
@@ -1062,6 +1095,7 @@ impl Randr {
                 render_device: dev.render_device,
                 use_plane_color_pipelines: dev.use_plane_color_pipelines,
                 plane_color_pipelines_supported: dev.plane_color_pipelines_supported,
+                flip_margin_auto_adjustment: dev.flip_margin_auto_adjustment,
                 connectors: connectors.into_iter().map(make_json_connector).collect(),
             });
         }
@@ -1117,6 +1151,10 @@ impl Randr {
         println!("    pci-id: {:x}:{:x}", dev.vendor, dev.model);
         println!("    syspath: {}", dev.syspath);
         println!("    api: {}", dev.gfx_api);
+        println!(
+            "    automatic flip-margin adjustment: {}",
+            dev.flip_margin_auto_adjustment
+        );
         if dev.render_device {
             println!("    primary device");
         }
@@ -1323,6 +1361,7 @@ impl Randr {
                 render_device: msg.render_device != 0,
                 use_plane_color_pipelines: false,
                 plane_color_pipelines_supported: false,
+                flip_margin_auto_adjustment: true,
             });
         });
         jay_randr::PlaneColorPipelines::handle(tc, randr, data.clone(), |data, msg| {
@@ -1330,6 +1369,11 @@ impl Randr {
             let d = data.drm_devices.last_mut().unwrap();
             d.use_plane_color_pipelines = msg.enabled != 0;
             d.plane_color_pipelines_supported = msg.supported != 0;
+        });
+        jay_randr::FlipMarginAutoAdjustment::handle(tc, randr, data.clone(), |data, msg| {
+            if let Some(dev) = data.borrow_mut().drm_devices.last_mut() {
+                dev.flip_margin_auto_adjustment = msg.enabled != 0;
+            }
         });
         jay_randr::Connector::handle(tc, randr, data.clone(), |data, msg| {
             let mut data = data.borrow_mut();

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -1176,6 +1176,28 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
+    fn handle_set_flip_margin_auto_adjustment_enabled(
+        &self,
+        device: DrmDevice,
+        enabled: bool,
+    ) -> Result<(), CphError> {
+        self.get_drm_device(device)?
+            .set_flip_margin_auto_adjustment_enabled(&self.state, enabled);
+        Ok(())
+    }
+
+    fn handle_get_flip_margin_auto_adjustment_enabled(
+        &self,
+        device: DrmDevice,
+    ) -> Result<(), CphError> {
+        let enabled = self
+            .get_drm_device(device)?
+            .dev
+            .flip_margin_auto_adjustment_enabled();
+        self.respond(Response::GetFlipMarginAutoAdjustmentEnabled { enabled });
+        Ok(())
+    }
+
     fn handle_set_x_scaling_mode(&self, mode: XScalingMode) -> Result<(), CphError> {
         let use_wire_scale = match mode {
             XScalingMode::DEFAULT => false,
@@ -3654,6 +3676,12 @@ impl ConfigProxyHandler {
             ClientMessage::SetFlipMargin { device, margin } => self
                 .handle_set_flip_margin(device, margin)
                 .wrn("set_flip_margin")?,
+            ClientMessage::SetFlipMarginAutoAdjustmentEnabled { device, enabled } => self
+                .handle_set_flip_margin_auto_adjustment_enabled(device, enabled)
+                .wrn("set_flip_margin_auto_adjustment_enabled")?,
+            ClientMessage::GetFlipMarginAutoAdjustmentEnabled { device } => self
+                .handle_get_flip_margin_auto_adjustment_enabled(device)
+                .wrn("get_flip_margin_auto_adjustment_enabled")?,
             ClientMessage::SetUiDragEnabled { enabled } => self.handle_set_ui_drag_enabled(enabled),
             ClientMessage::SetUiDragThreshold { threshold } => {
                 self.handle_set_ui_drag_threshold(threshold)

--- a/src/control_center/cc_gpus.rs
+++ b/src/control_center/cc_gpus.rs
@@ -146,6 +146,12 @@ impl GpusPane {
                         dev.set_flip_margin(&self.state, v);
                     }
                 }
+                bool(
+                    ui,
+                    "Automatic Flip-Margin Adjustment",
+                    dev.dev.flip_margin_auto_adjustment_enabled(),
+                    |v| dev.set_flip_margin_auto_adjustment_enabled(&self.state, v),
+                );
             });
             CollapsingHeader::new("Connectors")
                 .default_open(true)

--- a/src/ifs/jay_randr.rs
+++ b/src/ifs/jay_randr.rs
@@ -51,6 +51,7 @@ const NATIVE_GAMUT_SINCE: Version = Version(23);
 const ARBITRARY_MODES_SINCE: Version = Version(29);
 const SCALING_FILTER_SINCE: Version = Version(37);
 const USE_PLANE_COLOR_PIPELINES_SINCE: Version = Version(38);
+const FLIP_MARGIN_AUTO_ADJUSTMENT_SINCE: Version = Version(39);
 
 impl JayRandr {
     pub fn new(id: JayRandrId, client: &Rc<Client>, version: Version) -> Self {
@@ -88,6 +89,12 @@ impl JayRandr {
                 self_id: self.id,
                 enabled: data.dev.use_plane_color_pipelines() as _,
                 supported: data.dev.supports_plane_color_pipelines() as _,
+            });
+        }
+        if self.version >= FLIP_MARGIN_AUTO_ADJUSTMENT_SINCE {
+            self.client.event(FlipMarginAutoAdjustment {
+                self_id: self.id,
+                enabled: data.dev.flip_margin_auto_adjustment_enabled() as _,
             });
         }
     }
@@ -676,6 +683,18 @@ impl JayRandrRequestHandler for JayRandr {
             return Ok(());
         };
         dev.set_use_plane_color_pipelines(&self.state, req.enabled != 0);
+        Ok(())
+    }
+
+    fn set_flip_margin_auto_adjustment(
+        &self,
+        req: SetFlipMarginAutoAdjustment<'_>,
+        _slf: &Rc<Self>,
+    ) -> Result<(), Self::Error> {
+        let Some(dev) = self.get_device(req.dev) else {
+            return Ok(());
+        };
+        dev.set_flip_margin_auto_adjustment_enabled(&self.state, req.enabled != 0);
         Ok(())
     }
 }

--- a/src/it/test_backend.rs
+++ b/src/it/test_backend.rs
@@ -129,6 +129,7 @@ impl TestBackend {
         let default_drm_dev = Rc::new(TestDrmDevice {
             id: state.drm_dev_ids.next(),
             dev_t: 1234,
+            flip_margin_auto_adjustment_enabled: Cell::new(true),
         });
         let default_connector = Rc::new(TestConnector {
             id: state.connector_ids.next(),
@@ -773,6 +774,7 @@ impl<T: TestInputDevice> InputDevice for T {
 pub struct TestDrmDevice {
     id: DrmDeviceId,
     dev_t: dev_t,
+    flip_margin_auto_adjustment_enabled: Cell<bool>,
 }
 
 impl BackendDrmDevice for TestDrmDevice {
@@ -814,5 +816,13 @@ impl BackendDrmDevice for TestDrmDevice {
 
     fn is_render_device(&self) -> bool {
         true
+    }
+
+    fn set_flip_margin_auto_adjustment_enabled(&self, enabled: bool) {
+        self.flip_margin_auto_adjustment_enabled.set(enabled);
+    }
+
+    fn flip_margin_auto_adjustment_enabled(&self) -> bool {
+        self.flip_margin_auto_adjustment_enabled.get()
     }
 }

--- a/src/it/test_config.rs
+++ b/src/it/test_config.rs
@@ -23,6 +23,7 @@ use jay_config::theme::BarPosition;
 use jay_config::theme::sized::BAR_SEPARATOR_WIDTH;
 use jay_config::theme::sized::Resizable;
 use jay_config::video::Connector;
+use jay_config::video::DrmDevice;
 use jay_config::video::Transform;
 use std::cell::Cell;
 use std::ops::Deref;
@@ -310,6 +311,24 @@ impl TestConfig {
             connector: Connector(output.global.connector.connector.id().raw() as _),
             transform,
         })
+    }
+
+    pub fn set_flip_margin_auto_adjustment_enabled(
+        &self,
+        device: DrmDevice,
+        enabled: bool,
+    ) -> TestResult {
+        self.send(ClientMessage::SetFlipMarginAutoAdjustmentEnabled { device, enabled })
+    }
+
+    pub fn flip_margin_auto_adjustment_enabled(
+        &self,
+        device: DrmDevice,
+    ) -> Result<bool, TestError> {
+        let reply =
+            self.send_with_reply(ClientMessage::GetFlipMarginAutoAdjustmentEnabled { device })?;
+        get_response!(reply, GetFlipMarginAutoAdjustmentEnabled { enabled });
+        Ok(enabled)
     }
 
     pub fn set_size(&self, sized: Resizable, size: i32) -> TestResult {

--- a/src/it/tests.rs
+++ b/src/it/tests.rs
@@ -91,6 +91,7 @@ mod t0057_sm_floating;
 mod t0058_sm_parent;
 mod t0059_sm_background_ws;
 mod t0060_overlay;
+mod t0061_flip_margin_auto_adjustment;
 
 pub trait TestCase: Sync {
     fn name(&self) -> &'static str;
@@ -170,5 +171,6 @@ pub fn tests() -> Vec<&'static dyn TestCase> {
         t0058_sm_parent,
         t0059_sm_background_ws,
         t0060_overlay,
+        t0061_flip_margin_auto_adjustment,
     }
 }

--- a/src/it/tests/t0061_flip_margin_auto_adjustment.rs
+++ b/src/it/tests/t0061_flip_margin_auto_adjustment.rs
@@ -1,0 +1,33 @@
+use crate::backend::BackendDrmDevice;
+use crate::backend::BackendEvent;
+use crate::it::test_error::TestError;
+use crate::it::testrun::TestRun;
+use jay_config::video::DrmDevice;
+use std::rc::Rc;
+
+testcase!();
+
+/// Test that flip-margin auto-adjustment can be read and changed.
+async fn test(run: Rc<TestRun>) -> Result<(), TestError> {
+    run.state.backend_events.push(BackendEvent::NewDrmDevice(
+        run.backend.default_drm_dev.clone(),
+    ));
+    run.sync().await;
+
+    let backend_device = &run.backend.default_drm_dev;
+    let device = DrmDevice(backend_device.id().raw() as _);
+
+    tassert!(run.cfg.flip_margin_auto_adjustment_enabled(device)?);
+
+    run.cfg
+        .set_flip_margin_auto_adjustment_enabled(device, false)?;
+    tassert!(!backend_device.flip_margin_auto_adjustment_enabled());
+    tassert!(!run.cfg.flip_margin_auto_adjustment_enabled(device)?);
+
+    run.cfg
+        .set_flip_margin_auto_adjustment_enabled(device, true)?;
+    tassert!(backend_device.flip_margin_auto_adjustment_enabled());
+    tassert!(run.cfg.flip_margin_auto_adjustment_enabled(device)?);
+
+    Ok(())
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -743,6 +743,11 @@ impl DrmDevData {
         state.trigger_cci(CCI_GPUS);
         state.damage_full(RenderTL);
     }
+
+    pub fn set_flip_margin_auto_adjustment_enabled(&self, state: &State, enabled: bool) {
+        self.dev.set_flip_margin_auto_adjustment_enabled(enabled);
+        state.trigger_cci(CCI_GPUS);
+    }
 }
 
 struct UpdateTextTexturesVisitor;

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -507,6 +507,7 @@ pub struct ConfigDrmDevice {
     pub direct_scanout_enabled: Option<bool>,
     pub flip_margin_ms: Option<f64>,
     pub plane_color_pipelines_enabled: Option<bool>,
+    pub flip_margin_auto_adjustment: Option<bool>,
 }
 
 #[derive(Debug, Clone)]
@@ -695,4 +696,20 @@ where
 fn default_config_parses() {
     let input = include_bytes!("default-config.toml");
     parse_config(input, &Default::default(), &mut Default::default(), |_| ()).unwrap();
+}
+
+#[test]
+fn flip_margin_auto_adjustment_parses() {
+    let input = br#"
+        [[drm-devices]]
+        match.pci-vendor = 0x1002
+        flip-margin-ms = 1.0
+        flip-margin-auto-adjustment = false
+    "#;
+    let config = parse_config(input, &Default::default(), &mut Default::default(), |_| ()).unwrap();
+    assert_eq!(config.drm_devices.len(), 1);
+    assert_eq!(
+        config.drm_devices[0].flip_margin_auto_adjustment,
+        Some(false)
+    );
 }

--- a/toml-config/src/config/parsers/drm_device.rs
+++ b/toml-config/src/config/parsers/drm_device.rs
@@ -55,6 +55,7 @@ impl Parser for DrmDeviceParser<'_, '_> {
             gfx_api_val,
             flip_margin_ms,
             plane_color_pipelines_enabled,
+            flip_margin_auto_adjustment,
         ) = ext.extract((
             opt(str("name")),
             val("match"),
@@ -62,6 +63,7 @@ impl Parser for DrmDeviceParser<'_, '_> {
             opt(val("gfx-api")),
             recover(opt(fltorint("flip-margin-ms"))),
             recover(opt(bol("plane-color-pipelines"))),
+            recover(opt(bol("flip-margin-auto-adjustment"))),
         ))?;
         let gfx_api = match gfx_api_val {
             Some(api) => match api.parse(&mut GfxApiParser) {
@@ -94,6 +96,7 @@ impl Parser for DrmDeviceParser<'_, '_> {
             gfx_api,
             flip_margin_ms: flip_margin_ms.despan(),
             plane_color_pipelines_enabled: plane_color_pipelines_enabled.despan(),
+            flip_margin_auto_adjustment: flip_margin_auto_adjustment.despan(),
         })
     }
 }

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -637,6 +637,9 @@ impl ConfigDrmDevice {
         if let Some(v) = self.plane_color_pipelines_enabled {
             d.set_plane_color_pipelines_enabled(v);
         }
+        if let Some(enabled) = self.flip_margin_auto_adjustment {
+            d.set_flip_margin_auto_adjustment_enabled(enabled);
+        }
     }
 }
 

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -1422,6 +1422,10 @@
         "plane-color-pipelines": {
           "type": "boolean",
           "description": "If specified, enables or disables the use of plane color pipelines for this\ndevice.\n\nThe default is `false`.\n"
+        },
+        "flip-margin-auto-adjustment": {
+          "type": "boolean",
+          "description": "Whether the compositor may dynamically increase the flip margin when page flips are\nmissed. This is enabled by default. Disable this to keep `flip-margin-ms` fixed and drop\nframes instead of increasing input latency.\n"
         }
       },
       "required": [

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -2904,6 +2904,14 @@ The table has the following fields:
 
   The value of this field should be a boolean.
 
+- `flip-margin-auto-adjustment` (optional):
+
+  Whether the compositor may dynamically increase the flip margin when page flips are
+  missed. This is enabled by default. Disable this to keep `flip-margin-ms` fixed and drop
+  frames instead of increasing input latency.
+
+  The value of this field should be a boolean.
+
 
 <a name="types-DrmDeviceMatch"></a>
 ### `DrmDeviceMatch`

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -1611,6 +1611,13 @@ DrmDevice:
         device.
         
         The default is `false`.
+    flip-margin-auto-adjustment:
+      kind: boolean
+      required: false
+      description: |
+        Whether the compositor may dynamically increase the flip margin when page flips are
+        missed. This is enabled by default. Disable this to keep `flip-margin-ms` fixed and drop
+        frames instead of increasing input latency.
 
 
 GfxApi:

--- a/wire/jay_randr.txt
+++ b/wire/jay_randr.txt
@@ -123,6 +123,11 @@ request set_plane_color_pipelines (since = 38) {
     enabled: u32,
 }
 
+request set_flip_margin_auto_adjustment (since = 39) {
+    dev: str,
+    enabled: u32,
+}
+
 # events
 
 event global {
@@ -258,4 +263,8 @@ event scaling_filter (since = 37) {
 event plane_color_pipelines (since = 38) {
     enabled: u32,
     supported: u32,
+}
+
+event flip_margin_auto_adjustment (since = 39) {
+    enabled: u32,
 }


### PR DESCRIPTION
Closes #1051.

## Summary

- add a per-DRM-device `flip-margin-auto-adjustment` setting, enabled by default
- keep the configured flip margin fixed when adjustment is disabled, resetting any previously increased margin immediately
- expose the setting through `jay-config` and document it in the generated TOML spec and Jay Book
- add parser, CLI, and integration regression coverage

## Testing

- `cargo check --workspace` in Linux
- `cargo test --profile=ci` in Linux (`70 passed`)
- `cargo build --profile=ci --features it` in Linux
- `cd toml-config && cargo test --profile=ci` in Linux (`4 passed`)
- nightly `cargo fmt --all -- --check`
- regenerated the wire and TOML-spec outputs and verified both generators are idempotent
- `git diff --check`

## AI assistance

Codex was used for implementation and rebase assistance. The resulting changes were reviewed against the maintainer feedback and validated with the commands above.
