### PR TITLE
metal: fill HDR_OUTPUT_METADATA with display values

### DIFF
--- a/src/backends/metal/transaction.rs
+++ b/src/backends/metal/transaction.rs
@@ -795,7 +795,11 @@ impl MetalDeviceTransaction {
                 let new = if state.eotf == BackendEotfs::Default {
                     None
                 } else {
-                    Some(hdr_output_metadata::from_eotf(state.eotf.to_drm()))
+                    Some(hdr_output_metadata::from_eotf(
+                        state.eotf.to_drm(),
+                        &dd.primaries,
+                        dd.luminance.as_ref(),
+                    ))
                 };
                 if connector.new.hdr_metadata != new {
                     if let Some(new) = &new {

--- a/src/backends/metal/video.rs
+++ b/src/backends/metal/video.rs
@@ -1431,6 +1431,8 @@ fn create_connector_display_data(
     if let Some(p) = &hdr_metadata_prop {
         hdr_metadata = Some(hdr_output_metadata::from_eotf(
             HDMI_EOTF_TRADITIONAL_GAMMA_SDR,
+            &primaries,
+            luminance.as_ref(),
         ));
         if p.value.is_some() {
             match dev.master.getblob::<hdr_output_metadata>(p.value) {

--- a/src/backends/metal/video.rs
+++ b/src/backends/metal/video.rs
@@ -1323,7 +1323,7 @@ fn create_connector_display_data(
                                 luminance = Some(BackendLuminance {
                                     min: h.min_luminance.unwrap_or(0.0),
                                     max,
-                                    max_fall: h.max_luminance.unwrap_or(max),
+                                    max_fall: h.max_frame_average_luminance.unwrap_or(max),
                                 });
                             }
                         }

--- a/src/video/drm.rs
+++ b/src/video/drm.rs
@@ -2,12 +2,15 @@ pub mod syncobj;
 mod sys;
 
 use crate::backend;
+use crate::backend::BackendLuminance;
+use crate::cmm::cmm_primaries::Primaries;
 use crate::format::Format;
 use crate::io_uring::IoUring;
 use crate::io_uring::IoUringError;
 use crate::utils::bhash::BHashMap;
 use crate::utils::buf::Buf;
 use crate::utils::errorfmt::ErrorFmt;
+use crate::utils::ordered_float::F64;
 use crate::utils::oserror::OsError;
 use crate::utils::oserror::OsErrorExt2;
 use crate::utils::reset::Reset;
@@ -909,11 +912,33 @@ impl hdr_output_metadata {
         }
     }
 
-    pub fn from_eotf(eotf: u8) -> Self {
+    pub fn from_eotf(
+        eotf: u8,
+        primaries: &Primaries,
+        luminance: Option<&BackendLuminance>,
+    ) -> Self {
+        let map = |v: F64| (v.0 / 0.00002).round() as u16;
+        let map_coordinate = |(x, y): (F64, F64)| hdr_metadata_primary {
+            x: map(x),
+            y: map(y),
+        };
+        let (min, max) = match luminance {
+            None => (0, 0),
+            Some(v) => ((v.min / 0.0001).round() as u16, v.max_fall.round() as u16),
+        };
         Self::new(hdr_metadata_infoframe {
             eotf,
             metadata_type: 0,
-            ..hdr_metadata_infoframe::default()
+            display_primaries: [
+                map_coordinate(primaries.r),
+                map_coordinate(primaries.g),
+                map_coordinate(primaries.b),
+            ],
+            white_point: map_coordinate(primaries.wp),
+            max_display_mastering_luminance: max,
+            min_display_mastering_luminance: min,
+            max_cll: max,
+            max_fall: max,
         })
     }
 }


### PR DESCRIPTION
This seems to be what KDE does.