### PR TITLE
container: configure solitary border width

### DIFF
--- a/book/src/configuration/theme.md
+++ b/book/src/configuration/theme.md
@@ -109,6 +109,10 @@ highlight-color = "#f5c2e7"
 `bar-separator-width`
 : Width of the bar's bottom separator (px). Default: `1`.
 
+`container-border-width-solitary`
+: Border width for a container that is the only container on its workspace
+  (px). Defaults to `border-width`.
+
 ```toml
 [theme]
 border-width = 2

--- a/jay-config/src/theme.rs
+++ b/jay-config/src/theme.rs
@@ -423,5 +423,12 @@ pub mod sized {
         ///
         /// Default: 1
         const 04 => BAR_SEPARATOR_WIDTH,
+        /// The width of the border drawn around a container that is the only
+        /// container on its workspace
+        ///
+        /// This requires `Full` [`ContainerBorders`].
+        ///
+        /// Default: The `BORDER_WIDTH`.
+        const 05 => CONTAINER_BORDER_WIDTH_SOLITARY,
     }
 }

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -2864,6 +2864,7 @@ impl ConfigProxyHandler {
             BORDER_WIDTH => ThemeSized::border_width,
             BAR_HEIGHT => ThemeSized::bar_height,
             BAR_SEPARATOR_WIDTH => ThemeSized::bar_separator_width,
+            CONTAINER_BORDER_WIDTH_SOLITARY => ThemeSized::container_border_width_solitary,
             _ => return Err(CphError::UnknownSized(sized.0)),
         };
         Ok(sized)

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -528,6 +528,14 @@ impl ThemeSizes {
     pub fn bar_separator_width(&self, tl: TreeTimeline) -> i32 {
         self.bar_separator_width.get(tl)
     }
+
+    pub fn container_border_width_solitary(&self, tl: TreeTimeline) -> i32 {
+        if self.container_border_width_solitary.set[tl].get() {
+            self.container_border_width_solitary.val[tl].get()
+        } else {
+            self.border_width.val[tl].get()
+        }
+    }
 }
 
 sizes! {
@@ -535,6 +543,7 @@ sizes! {
     bar_height = (0, 1000, 17),
     border_width = (0, 1000, 4),
     bar_separator_width = (0, 1000, 1),
+    container_border_width_solitary = (0, 1000, 4),
 }
 
 impl StaticText for ThemeSized {
@@ -544,6 +553,7 @@ impl StaticText for ThemeSized {
             ThemeSized::bar_height => "Bar Height",
             ThemeSized::border_width => "Border Width",
             ThemeSized::bar_separator_width => "Bar Separator Width",
+            ThemeSized::container_border_width_solitary => "Container Border Width (Solitary)",
         }
     }
 }
@@ -689,6 +699,14 @@ impl Theme {
             self.sizes.title_height.get(tl) + 1
         } else {
             0
+        }
+    }
+
+    pub fn container_border_width(&self, tl: TreeTimeline, solitary: bool) -> i32 {
+        if solitary {
+            self.sizes.container_border_width_solitary(tl)
+        } else {
+            self.sizes.border_width.get(tl)
         }
     }
 

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -517,6 +517,10 @@ impl ContainerNode {
         }
     }
 
+    fn is_solitary(self: &Rc<Self>) -> bool {
+        self.num_children.get() <= 1 && self.toplevel_data.is_root_container.get()
+    }
+
     fn perform_layout(self: &Rc<Self>) {
         if self.num_children.get() == 0 {
             return;
@@ -549,7 +553,7 @@ impl ContainerNode {
 
         let theme = &self.state.theme;
         let th = theme.title_height(LiveTL);
-        let bw = theme.sizes.border_width.get(LiveTL);
+        let bw = theme.container_border_width(LiveTL, self.is_solitary());
         let num_children = self.num_children.get() as i32;
         let sp = match theme.container_borders[LiveTL].get() {
             ContainerBorders::Separators => 0,
@@ -573,7 +577,7 @@ impl ContainerNode {
     fn perform_split_layout(self: &Rc<Self>) {
         let sum_factors = self.sum_factors.get();
         let theme = &self.state.theme;
-        let border_width = theme.sizes.border_width.get(LiveTL);
+        let border_width = theme.container_border_width(LiveTL, self.is_solitary());
         let title_height_tmp = theme.title_height(LiveTL);
         let title_plus_underline_height = theme.title_plus_underline_height(LiveTL);
         let ns = &self.node_state[LiveTL];
@@ -692,7 +696,7 @@ impl ContainerNode {
 
     fn update_content_size(self: &Rc<Self>) {
         let theme = &self.state.theme;
-        let border_width = theme.sizes.border_width.get(LiveTL);
+        let border_width = theme.container_border_width(LiveTL, self.is_solitary());
         let title_plus_underline_height = theme.title_plus_underline_height(LiveTL);
         let nc = self.num_children.get();
         let ns = &self.node_state[LiveTL];
@@ -984,7 +988,7 @@ impl ContainerNode {
         let th = theme.title_height(RenderTL);
         let tpuh = theme.title_plus_underline_height(RenderTL);
         let tuh = theme.title_underline_height(RenderTL);
-        let bw = theme.sizes.border_width.get(RenderTL);
+        let bw = theme.container_border_width(RenderTL, self.is_solitary());
         let ns = &self.node_state[RenderTL];
         let cb = theme.container_borders[RenderTL].get();
         let sp = match cb {

--- a/src/tree/workspace.rs
+++ b/src/tree/workspace.rs
@@ -253,6 +253,7 @@ impl WorkspaceNode {
         container.tl_set_parent(self.clone());
         container.tl_set_visible(self.container_visible());
         self.set_ns_container(Some(container));
+        container.on_spaces_changed();
     }
 
     pub fn is_empty(&self) -> bool {

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -265,6 +265,7 @@ pub struct Theme {
     pub show_window_icons: Option<bool>,
     pub window_icons_grayscale: Option<bool>,
     pub container_borders: Option<ContainerBorders>,
+    pub container_border_width_solitary: Option<i32>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/toml-config/src/config/parsers/theme.rs
+++ b/toml-config/src/config/parsers/theme.rs
@@ -75,6 +75,7 @@ impl Parser for ThemeParser<'_, '_> {
                 show_window_icons,
                 window_icons_grayscale,
                 container_borders_val,
+                container_border_width_solitary,
                 focused_border_color,
             ),
         ) = ext.extract((
@@ -109,6 +110,7 @@ impl Parser for ThemeParser<'_, '_> {
                 recover(opt(bol("show-window-icons"))),
                 recover(opt(bol("window-icons-grayscale"))),
                 recover(opt(str("container-borders"))),
+                recover(opt(s32("container-border-width-solitary"))),
                 opt(val("focused-border-color")),
             ),
         ))?;
@@ -180,6 +182,7 @@ impl Parser for ThemeParser<'_, '_> {
             show_window_icons: show_window_icons.despan(),
             window_icons_grayscale: window_icons_grayscale.despan(),
             container_borders,
+            container_border_width_solitary: container_border_width_solitary.despan(),
         })
     }
 }

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -1142,6 +1142,7 @@ impl State {
         size!(TITLE_HEIGHT, title_height);
         size!(BAR_HEIGHT, bar_height);
         size!(BAR_SEPARATOR_WIDTH, bar_separator_width);
+        size!(CONTAINER_BORDER_WIDTH_SOLITARY, container_border_width_solitary);
         macro_rules! font {
             ($fun:ident, $field:ident) => {
                 if let Some(font) = &theme.$field {

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -2454,6 +2454,11 @@
         "container-borders": {
           "description": "The container border style. Defaults to `separators` if not set.",
           "$ref": "#/$defs/ContainerBorders"
+        },
+        "container-border-width-solitary": {
+          "type": "integer",
+          "description": "The width of the border around a container that is the only container on its workspace. Requires `full` container-borders. Defaults to `border-width` if not set.",
+          "minimum": 0.0
         }
       },
       "required": []

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -5491,6 +5491,16 @@ The table has the following fields:
 
   The value of this field should be a [ContainerBorders](#types-ContainerBorders).
 
+- `container-border-width-solitary` (optional):
+
+  The width of the border around a container that is the only container on its workspace. Requires `full` container-borders. Defaults to `border-width` if not set.
+
+  The value of this field should be a number.
+
+  The numbers should be integers.
+
+  The numbers should be greater than or equal to 0.
+
 
 <a name="types-TileState"></a>
 ### `TileState`

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -2630,6 +2630,12 @@ Theme:
       ref: ContainerBorders
       required: false
       description: The container border style. Defaults to `separators` if not set.
+    container-border-width-solitary:
+      kind: number
+      integer_only: true
+      minimum: 0
+      required: false
+      description: The width of the border around a container that is the only container on its workspace. Requires `full` container-borders. Defaults to `border-width` if not set.
 
 
 Config:


### PR DESCRIPTION
This allows me to specify `container-border-width-solitary = 0` for a "smart borders" setup to resolve https://github.com/mahkoh/jay/issues/1091.

