### PR TITLE
wl_pointer: skip axis_discrete events with discrete value 0

### DIFF
--- a/src/ifs/wl_seat/event_handling.rs
+++ b/src/ifs/wl_seat/event_handling.rs
@@ -1535,7 +1535,10 @@ impl WlSeatGlobal {
                     if p.seat.version >= AXIS_VALUE120_SINCE_VERSION {
                         p.send_axis_value120(axis, delta);
                     } else if p.seat.version >= AXIS_DISCRETE_SINCE_VERSION {
-                        p.send_axis_discrete(axis, delta / AXIS_120);
+                        let value = delta / AXIS_120;
+                        if value != 0 {
+                            p.send_axis_discrete(axis, value);
+                        }
                     }
                 }
                 if let Some(delta) = event.px[i].get() {


### PR DESCRIPTION
When running apps through Proton with the Wayland Wine driver enabled via `PROTON_ENABLE_WAYLAND=1`, my high-resolution scroll wheel on my Logitech G502 mouse does not work.

I investigated the issue with `WAYLAND_DEBUG=1` and discovered that various Proton versions (Proton-CachyOS, Proton-EM and Proton-GE) all use a patch from Wine-EM that disables support for high-resolution scroll events (`wl_pointer::axis_value120`) by downgrading the `wl_seat` protocol version from 8 to 5. Instead, deprecated axis click events (`wl_pointer::axis_discrete`) are used.

On KWin, the Wayland Wine driver receives eight scroll events accumulated into one:
```
wl_pointer.axis_discrete(0, 1)
wl_pointer.axis(..., 0, 15.0)
```

On Jay, these eight scroll events are sent separately, with the discrete value calculated as `delta ÷ AXIS_120 = 15 ÷ 120 = 0`:
```
wl_pointer.axis_discrete(0, 0)
wl_pointer.axis(..., 0, 1.875)
```

However, the Wine Wayland driver appears to assume KWin's behavior: when `wl_pointer::axis_discrete` is present, the value of `wl_pointer::axis` is ignored and only the discrete scroll path is used. As a result, with Jay, the continuous scroll information is discarded and no scroll event is generated. 

This should be fixed in Wine-EM with https://github.com/Etaash-mathamsetty/wine-valve/commit/e09d2f680dd58111f69e022f0d8a2deba0b1cede, but it might take some time until this patch is upstreamed to Wine and new releases of the Proton version ship it.

I don't think the protocol requires these `wl_pointer::axis_discrete` events with a discrete value of 0 to be sent in the first place, but I might be wrong about that, in which case you can just discard this PR. 

With this change scroll events work correctly in Proton, although in some apps scrolling is still slow or not very smooth at high speeds due to Windows apps not handling continuous scrolling very well. However, fixing that might require to replicate the KWin behavior by accumulating eight continuous scroll events into one complete discrete scroll step.