### PR TITLE
tree: add split-reuses-container option

### DIFF
--- a/book/src/configuration/misc.md
+++ b/book/src/configuration/misc.md
@@ -214,6 +214,19 @@ window-management-key = "Alt_L"
 The value should be a keysym name from
 [KBVM](https://docs.rs/kbvm/latest/kbvm/syms/index.html).
 
+## Split Reuses Container
+
+Controls whether splitting a window that is the only window in its container
+reuses that container.
+
+If this is disabled, splitting such a window wraps it in another container. If
+this is enabled, the split direction of the existing container is changed
+instead.
+
+```toml
+split-reuses-container = false  # default
+```
+
 ## Middle-Click Paste
 
 Controls whether middle-clicking pastes the primary selection. Changing this

--- a/book/src/configuration/shortcuts.md
+++ b/book/src/configuration/shortcuts.md
@@ -151,6 +151,11 @@ alt-shift-r = "reload-config-toml"
   `toggle-visualize-compositing` -- show or hide an overlay icon in the
   top-left corner of each output while the compositor is compositing. The icon
   disappears when content is shown via direct scanout.
+- `enable-split-reuses-container`, `disable-split-reuses-container`,
+  `toggle-split-reuses-container` -- control whether splitting a window that is
+  the only window in its container reuses that container instead of wrapping
+  it in another container. See
+  [`split-reuses-container`](misc.md#split-reuses-container).
 - `reload-config-so` -- reload the shared-library configuration (`config.so`)
 
 See the [specification](https://github.com/mahkoh/jay/blob/master/toml-spec/spec/spec.generated.md) for the full list of simple

--- a/book/src/control-center.md
+++ b/book/src/control-center.md
@@ -474,6 +474,11 @@ Float Pin Icon
 Float Above Fullscreen
 : Show floating windows above fullscreen windows
 
+Split Reuses Container
+: When splitting the only window in a container, change that container's split
+  direction instead of wrapping the window in a new container (see
+  [Split Reuses Container](configuration/misc.md#split-reuses-container))
+
 Font
 : Text field for the main compositor font family
 

--- a/book/src/tiling.md
+++ b/book/src/tiling.md
@@ -31,6 +31,11 @@ The `tile-horizontal` action sets the container to horizontal, and
 `tile-vertical` sets it to vertical -- unlike `split-horizontal`/`split-vertical`
 which wrap the window in a new container first.
 
+If the window being split is the only window in its container, the
+[`split-reuses-container`](configuration/misc.md#split-reuses-container)
+option makes the split change that container's direction instead of wrapping the
+window in a nested container.
+
 ## Moving Focus
 
 Move keyboard focus between windows with the directional focus actions:
@@ -138,10 +143,14 @@ Double-click a tile's title bar to toggle it between tiled and floating. See
 ## Summary of Tiling Actions
 
 `split-horizontal`
-: Wrap focused window in a horizontal container
+: Wrap focused window in a horizontal container (or, with
+  [`split-reuses-container`](configuration/misc.md#split-reuses-container),
+  make its container horizontal if it is the only window in it)
 
 `split-vertical`
-: Wrap focused window in a vertical container
+: Wrap focused window in a vertical container (or, with
+  [`split-reuses-container`](configuration/misc.md#split-reuses-container),
+  make its container vertical if it is the only window in it)
 
 `toggle-split`
 : Toggle container split direction

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -1155,6 +1155,16 @@ impl ConfigClient {
         above
     }
 
+    pub fn set_split_reuses_container(&self, reuse: bool) {
+        self.send(&ClientMessage::SetSplitReusesContainer { reuse });
+    }
+
+    pub fn get_split_reuses_container(&self) -> bool {
+        let res = self.send_with_response(&ClientMessage::GetSplitReusesContainer);
+        get_response!(res, false, GetSplitReusesContainer { reuse });
+        reuse
+    }
+
     pub fn set_show_bar(&self, show: bool) {
         self.send(&ClientMessage::SetShowBar { show });
     }

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -1014,6 +1014,10 @@ pub enum ClientMessage<'a> {
     GetWorkspacePosition {
         workspace: Workspace,
     },
+    SetSplitReusesContainer {
+        reuse: bool,
+    },
+    GetSplitReusesContainer,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -1299,6 +1303,9 @@ pub enum Response {
         y: i32,
         width: i32,
         height: i32,
+    },
+    GetSplitReusesContainer {
+        reuse: bool,
     },
 }
 

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -441,6 +441,10 @@ impl Seat {
     }
 
     /// Creates a new container with the specified split in place of the currently focused window.
+    ///
+    /// If the window is the only child of its container and
+    /// [`set_split_reuses_container`](crate::set_split_reuses_container) is enabled, the
+    /// split axis of that container is changed instead.
     pub fn create_split(self, axis: Axis) {
         get!().create_seat_split(self, axis);
     }

--- a/jay-config/src/lib.rs
+++ b/jay-config/src/lib.rs
@@ -489,6 +489,30 @@ pub fn set_show_float_pin_icon(show: bool) {
     get!().set_show_float_pin_icon(show);
 }
 
+/// Sets whether splitting a window that is the only child of its container reuses
+/// that container.
+///
+/// If disabled, splitting such a window wraps it in another container. If enabled, the
+/// split direction of the existing container is changed instead.
+///
+/// The default is `false`.
+pub fn set_split_reuses_container(reuse: bool) {
+    get!().set_split_reuses_container(reuse)
+}
+
+/// Returns whether splitting a window that is the only child of its container reuses
+/// that container.
+pub fn get_split_reuses_container() -> bool {
+    get!(false).get_split_reuses_container()
+}
+
+/// Toggles whether splitting a window that is the only child of its container reuses
+/// that container.
+pub fn toggle_split_reuses_container() {
+    let get = get!();
+    get.set_split_reuses_container(!get.get_split_reuses_container());
+}
+
 /// Sets whether the built-in bar is shown.
 ///
 /// The default is `true`.

--- a/jay-config/src/window.rs
+++ b/jay-config/src/window.rs
@@ -168,6 +168,10 @@ impl Window {
     }
 
     /// Creates a new container with the specified split in place of the window.
+    ///
+    /// If the window is the only child of its container and
+    /// [`set_split_reuses_container`](crate::set_split_reuses_container) is enabled, the
+    /// split axis of that container is changed instead.
     pub fn create_split(self, axis: Axis) {
         get!().create_window_split(self, axis);
     }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -449,6 +449,7 @@ fn start_compositor2(
         backend_connector_state_serials: Default::default(),
         head_names: Default::default(),
         show_bar: Cell::new(true),
+        split_reuses_container: Cell::new(false),
         enable_primary_selection: Cell::new(true),
         workspace_display_order: Cell::new(WorkspaceDisplayOrder::Manual),
         outputs_without_hc: Default::default(),

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -1817,6 +1817,16 @@ impl ConfigProxyHandler {
         });
     }
 
+    fn handle_set_split_reuses_container(&self, reuse: bool) {
+        self.state.set_split_reuses_container(reuse);
+    }
+
+    fn handle_get_split_reuses_container(&self) {
+        self.respond(Response::GetSplitReusesContainer {
+            reuse: self.state.split_reuses_container.get(),
+        });
+    }
+
     fn handle_set_show_bar(&self, show: bool) {
         self.state.set_show_bar(show);
     }
@@ -3858,6 +3868,10 @@ impl ConfigProxyHandler {
             ClientMessage::GetContentType { window } => self
                 .handle_get_content_type(window)
                 .wrn("get_content_type")?,
+            ClientMessage::SetSplitReusesContainer { reuse } => {
+                self.handle_set_split_reuses_container(reuse)
+            }
+            ClientMessage::GetSplitReusesContainer => self.handle_get_split_reuses_container(),
             ClientMessage::SetShowBar { show } => self.handle_set_show_bar(show),
             ClientMessage::GetShowBar => self.handle_get_show_bar(),
             ClientMessage::SetShowTitles { show } => self.handle_set_show_titles(show),

--- a/src/control_center/cc_look_and_feel.rs
+++ b/src/control_center/cc_look_and_feel.rs
@@ -119,6 +119,21 @@ impl LookAndFeelPane {
                 self.state.float_above_fullscreen.get(),
                 |v| self.state.set_float_above_fullscreen(v),
             );
+            bool_ui(
+                ui,
+                "Split Reuses Container",
+                |ui| {
+                    tip(ui, |ui| {
+                        ui.label(concat!(
+                            "Splitting the only window in a container changes the split ",
+                            "direction of that container.",
+                        ));
+                        ui.label("Otherwise the window is wrapped in a new container.");
+                    });
+                },
+                self.state.split_reuses_container.get(),
+                |v| self.state.set_split_reuses_container(v),
+            );
             row(ui, "Font", |ui| {
                 let mut v = self.state.theme.font.get().to_string();
                 if text_edit(ui, &mut v).changed() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -401,6 +401,7 @@ pub struct State {
     pub backend_connector_state_serials: BackendConnectorStateSerials,
     pub head_names: HeadNames,
     pub show_bar: Cell<bool>,
+    pub split_reuses_container: Cell<bool>,
     pub enable_primary_selection: Cell<bool>,
     pub workspace_display_order: Cell<WorkspaceDisplayOrder>,
     pub outputs_without_hc: NumCell<usize>,
@@ -2594,6 +2595,11 @@ impl State {
         let config = self.config.get()?;
         let initial = config.initial_output_for_workspace(name)?;
         Some(initial.map(|o| o.id))
+    }
+
+    pub fn set_split_reuses_container(&self, v: bool) {
+        self.split_reuses_container.set(v);
+        self.trigger_cci(CCI_LOOK_AND_FEEL);
     }
 }
 

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -1231,6 +1231,10 @@ impl ContainerNode {
         self.update_title();
     }
 
+    pub fn num_children(&self) -> usize {
+        self.num_children.get()
+    }
+
     pub fn set_split(self: &Rc<Self>, split: ContainerSplit) {
         if self.set_ns_split(split) != split {
             self.update_content_size();

--- a/src/tree/toplevel.rs
+++ b/src/tree/toplevel.rs
@@ -1177,6 +1177,13 @@ pub fn toplevel_create_split(state: &Rc<State>, tl: Rc<dyn ToplevelNode>, axis: 
         Some(ws) => ws,
         _ => return,
     };
+    if state.split_reuses_container.get()
+        && let Some(pn) = toplevel_parent_container(&*tl)
+        && pn.num_children() == 1
+    {
+        pn.set_split(axis);
+        return;
+    }
     let pn = match tl.tl_data().parent.get() {
         Some(pn) => pn,
         _ => return,

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -117,6 +117,8 @@ pub enum SimpleCommand {
     HideOverlays,
     SetVisualizeCompositing(bool),
     ToggleVisualizeCompositing,
+    SetSplitReusesContainer(bool),
+    ToggleSplitReusesContainer,
 }
 
 #[derive(Debug, Clone)]
@@ -611,6 +613,7 @@ pub struct Config {
     pub pointer_revert_key: Option<KeySym>,
     pub use_hardware_cursor: Option<bool>,
     pub show_bar: Option<bool>,
+    pub split_reuses_container: Option<bool>,
     pub show_titles: Option<bool>,
     pub focus_history: Option<FocusHistory>,
     pub middle_click_paste: Option<bool>,

--- a/toml-config/src/config/parsers/action.rs
+++ b/toml-config/src/config/parsers/action.rs
@@ -212,6 +212,9 @@ impl ActionParser<'_, '_, '_> {
             "enable-visualize-compositing" => SetVisualizeCompositing(true),
             "disable-visualize-compositing" => SetVisualizeCompositing(false),
             "toggle-visualize-compositing" => ToggleVisualizeCompositing,
+            "enable-split-reuses-container" => SetSplitReusesContainer(true),
+            "disable-split-reuses-container" => SetSplitReusesContainer(false),
+            "toggle-split-reuses-container" => ToggleSplitReusesContainer,
             _ => {
                 return Err(
                     ActionParserError::UnknownSimpleAction(string.to_string()).spanned(span)

--- a/toml-config/src/config/parsers/config.rs
+++ b/toml-config/src/config/parsers/config.rs
@@ -173,6 +173,7 @@ impl Parser for ConfigParser<'_, '_, '_> {
                 transactions_val,
                 cursor_size,
                 device_config_filter,
+                split_reuses_container,
             ),
         ) = ext.extract((
             (
@@ -240,6 +241,7 @@ impl Parser for ConfigParser<'_, '_, '_> {
                 opt(val("transactions")),
                 recover(opt(s32("cursor-size"))),
                 recover(opt(str("device-config-filter"))),
+                recover(opt(bol("split-reuses-container"))),
             ),
         ))?;
         let mut keymap = None;
@@ -677,6 +679,7 @@ impl Parser for ConfigParser<'_, '_, '_> {
             pointer_revert_key,
             use_hardware_cursor: use_hardware_cursor.despan(),
             show_bar: show_bar.despan(),
+            split_reuses_container: split_reuses_container.despan(),
             show_titles: show_titles.despan(),
             focus_history,
             middle_click_paste: middle_click_paste.despan(),

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -85,6 +85,7 @@ use jay_config::set_session_management_enabled;
 use jay_config::set_show_bar;
 use jay_config::set_show_float_pin_icon;
 use jay_config::set_show_titles;
+use jay_config::set_split_reuses_container;
 use jay_config::set_transaction_timeout;
 use jay_config::set_ui_drag_enabled;
 use jay_config::set_ui_drag_threshold;
@@ -111,6 +112,7 @@ use jay_config::theme::set_window_icons_grayscale;
 use jay_config::toggle_float_above_fullscreen;
 use jay_config::toggle_show_bar;
 use jay_config::toggle_show_titles;
+use jay_config::toggle_split_reuses_container;
 use jay_config::toggle_visualize_compositing;
 use jay_config::video::ColorSpace;
 use jay_config::video::Connector;
@@ -341,6 +343,10 @@ impl Action {
                     b.new(move || set_visualize_compositing(v))
                 }
                 SimpleCommand::ToggleVisualizeCompositing => b.new(toggle_visualize_compositing),
+                SimpleCommand::SetSplitReusesContainer(v) => {
+                    b.new(move || set_split_reuses_container(v))
+                }
+                SimpleCommand::ToggleSplitReusesContainer => b.new(toggle_split_reuses_container),
             },
             Action::Multi { actions } => {
                 let actions: Vec<_> = actions.into_iter().map(|a| a.into_fn(state)).collect();
@@ -1845,6 +1851,9 @@ fn load_config(initial_load: bool, auto_reload: bool, persistent: &Rc<Persistent
     }
     if let Some(v) = config.show_bar {
         set_show_bar(v);
+    }
+    if let Some(v) = config.split_reuses_container {
+        set_split_reuses_container(v);
     }
     if let Some(v) = config.show_titles {
         set_show_titles(v);

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -1237,6 +1237,10 @@
           "type": "boolean",
           "description": "Configures whether the default seat uses hardware cursors.\n\nThe default is `true`.\n"
         },
+        "split-reuses-container": {
+          "type": "boolean",
+          "description": "Configures whether splitting a window that is the only window in its\ncontainer reuses that container.\n\nIf this is disabled, splitting such a window wraps it in another\ncontainer. If this is enabled, the split direction of the existing\ncontainer is changed instead.\n\nThe default is `false`.\n"
+        },
         "show-bar": {
           "type": "boolean",
           "description": "Configures whether the built-in bar is shown.\n\nThe default is `true`.\n"
@@ -2253,6 +2257,9 @@
         "enable-float-above-fullscreen",
         "disable-float-above-fullscreen",
         "toggle-float-above-fullscreen",
+        "enable-split-reuses-container",
+        "disable-split-reuses-container",
+        "toggle-split-reuses-container",
         "pin-float",
         "unpin-float",
         "toggle-float-pinned",

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -2489,6 +2489,19 @@ The table has the following fields:
 
   The value of this field should be a boolean.
 
+- `split-reuses-container` (optional):
+
+  Configures whether splitting a window that is the only window in its
+  container reuses that container.
+  
+  If this is disabled, splitting such a window wraps it in another
+  container. If this is enabled, the split direction of the existing
+  container is changed instead.
+  
+  The default is `false`.
+
+  The value of this field should be a boolean.
+
 - `show-bar` (optional):
 
   Configures whether the built-in bar is shown.
@@ -5025,6 +5038,26 @@ The string should have one of the following values:
 - `toggle-float-above-fullscreen`:
 
   Toggles floating windows showing above fullscreen windows.
+
+- `enable-split-reuses-container`:
+
+  Enables reusing the container when splitting a window that is the only window
+  in its container.
+  
+  In this mode, splitting such a window changes the split direction of the
+  existing container.
+
+- `disable-split-reuses-container`:
+
+  Disables reusing the container when splitting a window that is the only window
+  in its container.
+  
+  In this mode, splitting such a window wraps it in another container.
+
+- `toggle-split-reuses-container`:
+
+  Toggles whether splitting a window that is the only window in its container
+  reuses that container.
 
 - `pin-float`:
 

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -1252,6 +1252,23 @@ SimpleActionName:
     - value: toggle-float-above-fullscreen
       description: |
         Toggles floating windows showing above fullscreen windows.
+    - value: enable-split-reuses-container
+      description: |
+        Enables reusing the container when splitting a window that is the only window
+        in its container.
+
+        In this mode, splitting such a window changes the split direction of the
+        existing container.
+    - value: disable-split-reuses-container
+      description: |
+        Disables reusing the container when splitting a window that is the only window
+        in its container.
+
+        In this mode, splitting such a window wraps it in another container.
+    - value: toggle-split-reuses-container
+      description: |
+        Toggles whether splitting a window that is the only window in its container
+        reuses that container.
     - value: pin-float
       description: |
         Pins the currently focused floating window.
@@ -3304,6 +3321,18 @@ Config:
         Configures whether the default seat uses hardware cursors.
 
         The default is `true`.
+    split-reuses-container:
+      kind: boolean
+      required: false
+      description: |
+        Configures whether splitting a window that is the only window in its
+        container reuses that container.
+
+        If this is disabled, splitting such a window wraps it in another
+        container. If this is enabled, the split direction of the existing
+        container is changed instead.
+
+        The default is `false`.
     show-bar:
       kind: boolean
       required: false


### PR DESCRIPTION
Splitting a window that is the only child of its container wraps it in
yet another single-child container, creating a redundant nesting level.
Repeating the split action builds a chain of such containers.

Add a split-reuses-container option (default off). When enabled,
splitting such a window changes the split direction of the existing
container instead of nesting a new one.

Expose via toml config, IPC (ConfigClient), and control-center toggle.