### PR TITLE
Add HDR screenshot option

### DIFF
--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -653,6 +653,33 @@ If no filename is given, the screenshot is saved as
 `%Y-%m-%d-%H%M%S_jay.<ext>` in the current directory. The filename supports
 strftime format specifiers.
 
+Capture in HDR10 instead of SDR:
+
+```shell
+~$ jay screenshot --hdr10
+~$ jay screenshot --hdr10 my-screenshot.png
+```
+
+`--hdr10`
+: Captures the screen with BT.2020 primaries and the PQ (SMPTE ST 2084)
+  transfer function. The result is a 16-bit-per-channel PNG carrying a `cICP`
+  chunk that identifies the HDR10 color space, so viewers that understand it
+  display the image with the correct colors and brightness. Without this flag,
+  screenshots are 8-bit sRGB.
+
+This works whether or not your display is currently in HDR mode -- it controls
+how the screenshot is encoded, not how the screen is driven. SDR content is
+captured at the ITU reference level of 203 cd/m^2, leaving the range above it
+for HDR content.
+
+> [!IMPORTANT]
+> `--hdr10` requires the Vulkan renderer. See
+> [HDR & Color Management](hdr.md) for how to check which renderer is in use.
+
+> [!NOTE]
+> `--hdr10` cannot be combined with `--format qoi`; QOI has no way to describe
+> a color space.
+
 ---
 
 ## Clients & Windows

--- a/book/src/hdr.md
+++ b/book/src/hdr.md
@@ -271,6 +271,43 @@ The output for each connector includes:
 - **Native gamut** -- the display's CIE xy primaries for red, green, blue, and
   white point.
 
+## HDR screenshots
+
+An ordinary screenshot is 8-bit sRGB, so any HDR content on screen is clipped
+or flattened to the SDR range. Pass `--hdr10` to capture in HDR instead:
+
+```shell
+~$ jay screenshot --hdr10
+~$ jay screenshot --hdr10 my-screenshot.png
+```
+
+The screen is captured with BT.2020 primaries and the PQ transfer function,
+and written as a 16-bit-per-channel PNG. The file carries a `cICP` chunk
+identifying the HDR10 color space, which is how a viewer knows to interpret
+the pixels as PQ rather than sRGB.
+
+Highlights are preserved up to the full PQ range, and SDR content is captured
+at the reference level of 203 cd/m^2, matching what the `pq` transfer function
+uses on a real output.
+
+You do not need to put your display into HDR mode first. The flag controls how
+the screenshot is encoded, not how the screen is driven, so an HDR10
+screenshot on an SDR display is captured correctly -- you simply won't be able
+to preview it accurately on that display.
+
+> [!IMPORTANT]
+> HDR screenshots require the Vulkan renderer, for the same reason HDR output
+> does. See [Prerequisites](#prerequisites) above.
+
+> [!NOTE]
+> `--hdr10` produces PNG only. It cannot be combined with `--format qoi`,
+> because QOI has no way to describe a color space.
+
+Support for HDR PNGs is still uneven across image viewers and browsers. A
+viewer that ignores the `cICP` chunk treats the file as ordinary 16-bit sRGB,
+which makes the image look flat and washed out. The file itself is still
+correct.
+
 ## Complete example
 
 A typical HDR configuration for a monitor that supports HDR10:
@@ -309,7 +346,7 @@ read-only indicator showing whether color management is currently available.
   reference including all color and HDR fields
 - [Miscellaneous](configuration/misc.md) -- the `[color-management]` config
   table
-- [Command-Line Interface](cli.md) -- `jay randr output` color commands and
-  `jay color-management`
+- [Command-Line Interface](cli.md) -- `jay randr output` color commands,
+  `jay color-management`, and `jay screenshot --hdr10`
 - [GPUs](configuration/gpu.md) -- renderer selection (Vulkan is required for
   HDR)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,6 +172,13 @@ pub struct ScreenshotArgs {
     /// The format to use for the image.
     #[clap(value_enum, long, default_value_t)]
     pub format: ScreenshotFormat,
+    /// Capture the screenshot as HDR10 (10-bit, BT.2020 primaries, ST 2084 PQ transfer
+    /// function) instead of SDR.
+    ///
+    /// Only supported for the PNG format. The resulting PNG is 16-bit-per-channel with
+    /// a cICP chunk describing the HDR10 color space.
+    #[clap(long)]
+    pub hdr10: bool,
     /// The filename of the saved screenshot
     ///
     /// If no filename is given, the screenshot will be saved under %Y-%m-%d-%H%M%S_jay.<ext>

--- a/src/cli/screenshot.rs
+++ b/src/cli/screenshot.rs
@@ -6,8 +6,12 @@ use crate::cli::GlobalArgs;
 use crate::cli::ScreenshotArgs;
 use crate::cli::ScreenshotFormat;
 use crate::eventfd_cache::EventfdCache;
+use crate::format::Format;
 use crate::format::XRGB8888;
+use crate::format::XRGB2101010;
+use crate::format::formats;
 use crate::gfx_apis;
+use crate::ifs::jay_compositor::SCREENSHOT_DMABUF3_SINCE;
 use crate::tools::tool_client::Handle;
 use crate::tools::tool_client::ToolClient;
 use crate::tools::tool_client::with_tool_client;
@@ -25,8 +29,10 @@ use crate::video::drm::DrmError;
 use crate::video::gbm::GbmDevice;
 use crate::video::gbm::GbmError;
 use crate::wire::jay_compositor::TakeScreenshot;
+use crate::wire::jay_compositor::TakeScreenshot3;
 use crate::wire::jay_screenshot::Dmabuf;
 use crate::wire::jay_screenshot::Dmabuf2;
+use crate::wire::jay_screenshot::Dmabuf3;
 use crate::wire::jay_screenshot::DrmDev;
 use crate::wire::jay_screenshot::Error;
 use crate::wire::jay_screenshot::Plane;
@@ -36,13 +42,22 @@ use png::BitDepth;
 use png::ColorType;
 use png::Encoder;
 use png::SrgbRenderingIntent;
+use png::chunk;
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::rc::Rc;
 use thiserror::Error;
 use uapi::OwnedFd;
 
+/// cICP chunk contents for HDR10: BT.2020 primaries, ST 2084 (PQ) transfer
+/// characteristics, identity matrix coefficients (PNG stores RGB, not YCbCr),
+/// full-range samples.
+const CICP_HDR10: [u8; 4] = [9, 16, 0, 1];
+
 pub fn main(_global: GlobalArgs, args: ScreenshotArgs) {
+    if args.hdr10 && args.format != ScreenshotFormat::Png {
+        fatal!("--hdr10 is only supported with --format=png");
+    }
     with_tool_client(|tc| async move {
         let screenshot = Rc::new(Screenshot {
             tc: tc.clone(),
@@ -61,10 +76,23 @@ async fn run(screenshot: Rc<Screenshot>) {
     let tc = &screenshot.tc;
     let comp = tc.jay_compositor().await;
     let sid = tc.id();
-    tc.send(TakeScreenshot {
-        self_id: comp,
-        id: sid,
-    });
+    let version = tc.jay_compositor_version().await;
+    if version >= SCREENSHOT_DMABUF3_SINCE {
+        tc.send(TakeScreenshot3 {
+            self_id: comp,
+            id: sid,
+            include_cursor: false,
+            hdr10: screenshot.args.hdr10,
+        });
+    } else {
+        if screenshot.args.hdr10 {
+            fatal!("The compositor does not support HDR10 screenshots");
+        }
+        tc.send(TakeScreenshot {
+            self_id: comp,
+            id: sid,
+        });
+    }
     let result = Rc::new(AsyncQueue::default());
     Error::handle(tc, sid, result.clone(), |res, err| {
         res.push(Err(err.msg.to_owned()));
@@ -101,13 +129,36 @@ async fn run(screenshot: Rc<Screenshot>) {
     Dmabuf2::handle(
         tc,
         sid,
-        (drm_dev, planes, result.clone()),
+        (drm_dev.clone(), planes.clone(), result.clone()),
         |(dev, planes, res), ev| {
             let buf = DmaBuf::new(
                 &DmaBufIds::default(),
                 ev.width,
                 ev.height,
                 XRGB8888,
+                ev.modifier,
+                planes.take(),
+            );
+            res.push(Ok((buf, dev.take())))
+        },
+    );
+    Dmabuf3::handle(
+        tc,
+        sid,
+        (drm_dev, planes, result.clone()),
+        |(dev, planes, res), ev| {
+            let Some(format) = formats().get(&ev.format).copied() else {
+                res.push(Err(format!(
+                    "Compositor sent an unknown format {}",
+                    ev.format
+                )));
+                return;
+            };
+            let buf = DmaBuf::new(
+                &DmaBufIds::default(),
+                ev.width,
+                ev.height,
+                format,
                 ev.modifier,
                 planes.take(),
             );
@@ -122,7 +173,13 @@ async fn run(screenshot: Rc<Screenshot>) {
     };
     let format = screenshot.args.format;
     let eventfd_cache = EventfdCache::new(&tc.ring, &tc.eng);
-    let data = match buf_to_bytes(&eventfd_cache, drm_dev.as_ref(), &buf, format) {
+    let data = match buf_to_bytes(
+        &eventfd_cache,
+        drm_dev.as_ref(),
+        &buf,
+        format,
+        screenshot.args.hdr10,
+    ) {
         Ok(d) => d,
         Err(e) => fatal!("{}", ErrorFmt(e)),
     };
@@ -158,6 +215,8 @@ pub enum ScreenshotError {
     CreateVulkanAllocator(#[source] AllocatorError),
     #[error("Could not map the dmabuf with any allocator")]
     MapDmabufAny,
+    #[error("Don't know how to encode format `{}` as a PNG", .0.name)]
+    UnknownFormat(&'static Format),
 }
 
 fn map(
@@ -176,6 +235,7 @@ pub fn buf_to_bytes(
     drm_dev: Option<&Rc<OwnedFd>>,
     buf: &Rc<DmaBuf>,
     format: ScreenshotFormat,
+    hdr10: bool,
 ) -> Result<Vec<u8>, ScreenshotError> {
     let mut allocators =
         Vec::<Box<dyn FnOnce() -> Result<Rc<dyn Allocator>, ScreenshotError>>>::new();
@@ -232,8 +292,33 @@ pub fn buf_to_bytes(
         ));
     }
 
-    let mut out = vec![];
-    {
+    // Decoding the raw buffer into 8- or 16-bit-per-channel RGBA is purely a function
+    // of the pixel format we got back from the compositor. Whether we annotate the
+    // resulting PNG as HDR10 (via a cICP chunk) is a separate question, controlled by
+    // whether we requested HDR10 from the compositor in the first place.
+    let (bit_depth, image_data) = if buf.format == XRGB2101010 {
+        // Unpack 10-bit-per-channel x:R:G:B samples (as used by XRGB2101010 /
+        // VK_FORMAT_A2R10G10B10_UNORM_PACK32) into 16-bit-per-channel RGBA, expanding
+        // each 10-bit value to 16 bits by replicating its high bits into the low bits
+        // so that 0 maps to 0 and 1023 maps to 65535.
+        let mut image_data = Vec::with_capacity((buf.width * buf.height * 8) as usize);
+        let lines = data[..(buf.height as usize * bo_map.stride() as usize)]
+            .chunks_exact(bo_map.stride() as usize);
+        for line in lines {
+            for pixel in line[..(buf.width as usize * 4)].array_chunks_ext::<4>() {
+                let word = u32::from_le_bytes(*pixel);
+                let r10 = (word >> 20) & 0x3ff;
+                let g10 = (word >> 10) & 0x3ff;
+                let b10 = word & 0x3ff;
+                let expand = |v: u32| -> [u8; 2] { (((v << 6) | (v >> 4)) as u16).to_be_bytes() };
+                image_data.extend_from_slice(&expand(r10));
+                image_data.extend_from_slice(&expand(g10));
+                image_data.extend_from_slice(&expand(b10));
+                image_data.extend_from_slice(&0xffffu16.to_be_bytes());
+            }
+        }
+        (BitDepth::Sixteen, image_data)
+    } else if buf.format == XRGB8888 {
         let mut image_data = Vec::with_capacity((buf.width * buf.height * 4) as usize);
         let lines = data[..(buf.height as usize * bo_map.stride() as usize)]
             .chunks_exact(bo_map.stride() as usize);
@@ -242,11 +327,24 @@ pub fn buf_to_bytes(
                 image_data.extend_from_slice(&[pixel[2], pixel[1], pixel[0], 255])
             }
         }
+        (BitDepth::Eight, image_data)
+    } else {
+        return Err(ScreenshotError::UnknownFormat(buf.format));
+    };
+
+    let mut out = vec![];
+    {
         let mut encoder = Encoder::new(&mut out, buf.width as _, buf.height as _);
         encoder.set_color(ColorType::Rgba);
-        encoder.set_depth(BitDepth::Eight);
-        encoder.set_source_srgb(SrgbRenderingIntent::Perceptual);
+        encoder.set_depth(bit_depth);
+        if !hdr10 {
+            encoder.set_source_srgb(SrgbRenderingIntent::Perceptual);
+        }
         let mut writer = encoder.write_header().unwrap();
+        if hdr10 {
+            // BT.2020 primaries, ST 2084 (PQ) transfer characteristics.
+            writer.write_chunk(chunk::cICP, &CICP_HDR10).unwrap();
+        }
         writer.write_image_data(&image_data).unwrap();
     }
     Ok(out)

--- a/src/format.rs
+++ b/src/format.rs
@@ -394,7 +394,7 @@ static ARGB2101010: &Format = &Format {
     ..default(ConfigFormat::ARGB2101010)
 };
 
-static XRGB2101010: &Format = &Format {
+pub static XRGB2101010: &Format = &Format {
     name: "xrgb2101010",
     vk_format: vk::Format::A2R10G10B10_UNORM_PACK32,
     bpp: 4,

--- a/src/ifs/jay_compositor.rs
+++ b/src/ifs/jay_compositor.rs
@@ -57,6 +57,7 @@ use thiserror::Error;
 pub const CREATE_EI_SESSION_SINCE: Version = Version(5);
 pub const SCREENSHOT_SPLITUP_SINCE: Version = Version(6);
 pub const GET_TOPLEVEL_SINCE: Version = Version(12);
+pub const SCREENSHOT_DMABUF3_SINCE: Version = Version(40);
 
 pub struct JayCompositorGlobal {
     name: GlobalName,
@@ -90,7 +91,7 @@ global_base!(JayCompositorGlobal, JayCompositor, JayCompositorError);
 
 impl Global for JayCompositorGlobal {
     fn version(&self) -> u32 {
-        39
+        40
     }
 
     fn required_caps(&self) -> ClientCaps {
@@ -127,6 +128,7 @@ impl JayCompositor {
         &self,
         id: JayScreenshotId,
         include_cursor: bool,
+        hdr10: bool,
     ) -> Result<(), JayCompositorError> {
         let ss = Rc::new(JayScreenshot {
             id,
@@ -135,7 +137,7 @@ impl JayCompositor {
         });
         track!(self.client, ss);
         self.client.add_client_obj(&ss)?;
-        match take_screenshot(&self.client.state, include_cursor) {
+        match take_screenshot(&self.client.state, include_cursor, hdr10) {
             Ok(s) => {
                 let dmabuf = s.bo.dmabuf();
                 if self.version < SCREENSHOT_SPLITUP_SINCE {
@@ -160,7 +162,11 @@ impl JayCompositor {
                     for plane in &dmabuf.planes {
                         ss.send_plane(plane);
                     }
-                    ss.send_dmabuf2(dmabuf);
+                    if self.version >= SCREENSHOT_DMABUF3_SINCE {
+                        ss.send_dmabuf3(dmabuf);
+                    } else {
+                        ss.send_dmabuf2(dmabuf);
+                    }
                 }
             }
             Err(e) => {
@@ -206,11 +212,15 @@ impl JayCompositorRequestHandler for JayCompositor {
     }
 
     fn take_screenshot(&self, req: TakeScreenshot, _slf: &Rc<Self>) -> Result<(), Self::Error> {
-        self.take_screenshot_impl(req.id, false)
+        self.take_screenshot_impl(req.id, false, false)
     }
 
     fn take_screenshot2(&self, req: TakeScreenshot2, _slf: &Rc<Self>) -> Result<(), Self::Error> {
-        self.take_screenshot_impl(req.id, req.include_cursor)
+        self.take_screenshot_impl(req.id, req.include_cursor, false)
+    }
+
+    fn take_screenshot3(&self, req: TakeScreenshot3, _slf: &Rc<Self>) -> Result<(), Self::Error> {
+        self.take_screenshot_impl(req.id, req.include_cursor, req.hdr10)
     }
 
     fn get_idle(&self, req: GetIdle, _slf: &Rc<Self>) -> Result<(), Self::Error> {

--- a/src/ifs/jay_screenshot.rs
+++ b/src/ifs/jay_screenshot.rs
@@ -70,6 +70,16 @@ impl JayScreenshot {
             modifier: buf.modifier,
         })
     }
+
+    pub fn send_dmabuf3(&self, buf: &DmaBuf) {
+        self.client.event(Dmabuf3 {
+            self_id: self.id,
+            width: buf.width,
+            height: buf.height,
+            modifier: buf.modifier,
+            format: buf.format.drm,
+        })
+    }
 }
 
 impl JayScreenshotRequestHandler for JayScreenshot {

--- a/src/it/test_client.rs
+++ b/src/it/test_client.rs
@@ -106,6 +106,7 @@ impl TestClient {
             dev.as_ref(),
             &dmabuf,
             ScreenshotFormat::Qoi,
+            false,
         )?;
         Ok(qoi)
     }

--- a/src/screenshoter.rs
+++ b/src/screenshoter.rs
@@ -2,7 +2,10 @@ use crate::allocator::AllocatorError;
 use crate::allocator::BO_USE_RENDERING;
 use crate::allocator::BufferObject;
 use crate::allocator::BufferUsage;
+use crate::cmm::cmm_eotf::Eotf;
+use crate::format::Format;
 use crate::format::XRGB8888;
+use crate::format::XRGB2101010;
 use crate::gfx_api::AcquireSync;
 use crate::gfx_api::GfxError;
 use crate::gfx_api::ReleaseSync;
@@ -31,10 +34,12 @@ pub enum ScreenshooterError {
     RenderError(#[from] GfxError),
     #[error(transparent)]
     DrmError(#[from] DrmError),
-    #[error("Render context does not support XRGB8888")]
-    XRGB8888,
-    #[error("Render context supports no modifiers for XRGB8888 rendering")]
-    Modifiers,
+    #[error("Render context does not support {}", .0.name)]
+    UnsupportedFormat(&'static Format),
+    #[error("Render context supports no modifiers for {} rendering", .0.name)]
+    Modifiers(&'static Format),
+    #[error("Renderer does not support color management")]
+    NoColorManagementSupport,
 }
 
 pub struct Screenshot {
@@ -45,18 +50,36 @@ pub struct Screenshot {
 pub fn take_screenshot(
     state: &State,
     include_cursor: bool,
+    hdr10: bool,
 ) -> Result<Screenshot, ScreenshooterError> {
     let ctx = match state.render_ctx.get() {
         Some(ctx) => ctx,
         _ => return Err(ScreenshooterError::NoRenderContext),
     };
+    if hdr10 && !ctx.supports_color_management() {
+        return Err(ScreenshooterError::NoColorManagementSupport);
+    }
     let extents = state.root.node_state[RenderTL].extents.get();
     if extents.is_empty() {
         return Err(ScreenshooterError::EmptyDisplay);
     }
+    // HDR10 output is 10-bit-per-channel BT.2020 primaries with an ST 2084 (PQ)
+    // transfer function. `windows_bt2100` is exactly that color description, so
+    // we reuse it here instead of introducing a separate one.
+    let format = if hdr10 { XRGB2101010 } else { XRGB8888 };
+    let (cd, blend_cd) = if hdr10 {
+        let cd = state.color_manager.windows_bt2100();
+        let blend_cd = state.color_manager.get_with_tf(cd, Eotf::Linear);
+        (cd, blend_cd)
+    } else {
+        (
+            state.color_manager.srgb_gamma22(),
+            state.color_manager.srgb_linear().clone(),
+        )
+    };
     let formats = ctx.formats();
-    let modifiers: IndexMap<_, _> = match formats.get(&XRGB8888.drm) {
-        None => return Err(ScreenshooterError::XRGB8888),
+    let modifiers: IndexMap<_, _> = match formats.get(&format.drm) {
+        None => return Err(ScreenshooterError::UnsupportedFormat(format)),
         Some(f) => f
             .write_modifiers
             .iter()
@@ -64,7 +87,7 @@ pub fn take_screenshot(
             .collect(),
     };
     if modifiers.is_empty() {
-        return Err(ScreenshooterError::Modifiers);
+        return Err(ScreenshooterError::Modifiers(format));
     }
     let mut usage = BO_USE_RENDERING;
     if !needs_render_usage(modifiers.values().copied()) {
@@ -76,7 +99,7 @@ pub fn take_screenshot(
         &state.dma_buf_ids,
         extents.width(),
         extents.height(),
-        XRGB8888,
+        format,
         &modifiers,
         usage,
     )?;
@@ -84,7 +107,7 @@ pub fn take_screenshot(
     fb.render_node(
         AcquireSync::Unnecessary,
         ReleaseSync::Implicit,
-        state.color_manager.srgb_gamma22(),
+        cd,
         state.root.deref(),
         state,
         Some(state.root.node_state[RenderTL].extents.get()),
@@ -96,7 +119,7 @@ pub fn take_screenshot(
         false,
         Transform::None,
         None,
-        state.color_manager.srgb_linear(),
+        &blend_cd,
         false,
     )?;
     let drm = match allocator.drm() {

--- a/src/tools/tool_client.rs
+++ b/src/tools/tool_client.rs
@@ -377,7 +377,7 @@ impl ToolClient {
             self_id: s.registry,
             name: s.jay_compositor.0,
             interface: JayCompositor.name(),
-            version: s.jay_compositor.1.min(39),
+            version: s.jay_compositor.1.min(40),
             id: id.into(),
         });
         self.jay_compositor.set(Some(id));

--- a/wire/jay_compositor.txt
+++ b/wire/jay_compositor.txt
@@ -157,6 +157,12 @@ request kill_matched_clients (since = 39) {
     id: id(jay_client_match),
 }
 
+request take_screenshot3 (since = 40) {
+    id: id(jay_screenshot),
+    include_cursor: bool,
+    hdr10: bool,
+}
+
 # events
 
 event client_id {

--- a/wire/jay_screenshot.txt
+++ b/wire/jay_screenshot.txt
@@ -29,3 +29,10 @@ event dmabuf2 (since = 6) {
     height: i32,
     modifier: pod(u64),
 }
+
+event dmabuf3 (since = 40) {
+    width: i32,
+    height: i32,
+    modifier: u64,
+    format: u32,
+}


### PR DESCRIPTION
Most likely needs to be cleaned up a little but adds `jay screenshot --hdr10` as an option in jay. Closes #1146.