### PR TITLE
config: add getters for size and position

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -643,6 +643,36 @@ impl ConfigClient {
         workspace
     }
 
+    pub fn get_window_position(&self, window: Window) -> (i32, i32, i32, i32) {
+        let res = self.send_with_response(&ClientMessage::GetWindowPosition { window });
+        get_response!(
+            res,
+            (0, 0, 0, 0),
+            GetWindowPosition {
+                x,
+                y,
+                width,
+                height
+            }
+        );
+        (x, y, width, height)
+    }
+
+    pub fn get_workspace_position(&self, workspace: Workspace) -> (i32, i32, i32, i32) {
+        let res = self.send_with_response(&ClientMessage::GetWorkspacePosition { workspace });
+        get_response!(
+            res,
+            (0, 0, 0, 0),
+            GetWorkspacePosition {
+                x,
+                y,
+                width,
+                height
+            }
+        );
+        (x, y, width, height)
+    }
+
     pub fn get_seat_keyboard_workspace(&self, seat: Seat) -> Workspace {
         let res = self.send_with_response(&ClientMessage::GetSeatKeyboardWorkspace { seat });
         get_response!(res, Workspace(0), GetSeatKeyboardWorkspace { workspace });

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -1008,6 +1008,12 @@ pub enum ClientMessage<'a> {
     GetPlaneColorPipelinesEnabled {
         device: DrmDevice,
     },
+    GetWindowPosition {
+        window: Window,
+    },
+    GetWorkspacePosition {
+        workspace: Workspace,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -1281,6 +1287,18 @@ pub enum Response {
     },
     GetPlaneColorPipelinesEnabled {
         enabled: bool,
+    },
+    GetWindowPosition {
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    },
+    GetWorkspacePosition {
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
     },
 }
 

--- a/jay-config/src/lib.rs
+++ b/jay-config/src/lib.rs
@@ -232,6 +232,22 @@ impl Workspace {
     pub fn set_initial_connector(self, connector: Option<Connector>) {
         get!().set_workspace_initial_connector(self, connector);
     }
+
+    /// Returns the position of the workspace in the global compositor space.
+    ///
+    /// This value is only accurate for visible workspaces.
+    pub fn position(self) -> (i32, i32) {
+        let (x, y, _, _) = get!((0, 0)).get_workspace_position(self);
+        (x, y)
+    }
+
+    /// Returns the size of the workspace.
+    ///
+    /// This value is only accurate for visible workspaces.
+    pub fn size(self) -> (i32, i32) {
+        let (_, _, width, height) = get!((0, 0)).get_workspace_position(self);
+        (width, height)
+    }
 }
 
 /// Returns the workspace with the given name.

--- a/jay-config/src/video.rs
+++ b/jay-config/src/video.rs
@@ -201,6 +201,16 @@ impl Connector {
         get!().connector_size(self).1
     }
 
+    /// Returns the logical size of the connector.
+    ///
+    /// This is a shortcut for `(width(), height())` that only performs a single round-trip.
+    pub fn size(self) -> (i32, i32) {
+        if !self.exists() {
+            return (0, 0);
+        }
+        get!((0, 0)).connector_size(self)
+    }
+
     /// Returns the refresh rate in mhz of the current mode of the connector.
     ///
     /// This is a shortcut for `mode().refresh_rate()`.

--- a/jay-config/src/window.rs
+++ b/jay-config/src/window.rs
@@ -241,6 +241,22 @@ impl Window {
     pub fn resize(self, dx1: i32, dy1: i32, dx2: i32, dy2: i32) {
         get!().resize_window(self, dx1, dy1, dx2, dy2);
     }
+
+    /// Returns the position of the window in the global compositor space.
+    ///
+    /// This value is only accurate for visible windows.
+    pub fn position(self) -> (i32, i32) {
+        let (x, y, _, _) = get!((0, 0)).get_window_position(self);
+        (x, y)
+    }
+
+    /// Returns the size of the window.
+    ///
+    /// This value is only accurate for visible windows.
+    pub fn size(self) -> (i32, i32) {
+        let (_, _, width, height) = get!((0, 0)).get_window_position(self);
+        (width, height)
+    }
 }
 
 /// A window matcher.

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -47,6 +47,7 @@ use crate::tagged_acceptor::TaggedAcceptorError;
 use crate::theme::ThemeColored;
 use crate::theme::ThemeSized;
 use crate::tree::ContainerSplit;
+use crate::tree::NodeBase;
 use crate::tree::OutputNode;
 use crate::tree::OutputNodeOrPersistent;
 use crate::tree::TearingMode;
@@ -3069,6 +3070,31 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
+    fn handle_get_window_position(&self, window: Window) -> Result<(), CphError> {
+        let pos = self.get_window(window)?.node_absolute_position(LiveTL);
+        self.respond(Response::GetWindowPosition {
+            x: pos.x1(),
+            y: pos.y1(),
+            width: pos.width(),
+            height: pos.height(),
+        });
+        Ok(())
+    }
+
+    fn handle_get_workspace_position(&self, workspace: Workspace) -> Result<(), CphError> {
+        let pos = self
+            .get_existing_workspace(workspace)?
+            .map(|ws| ws.node_absolute_position(LiveTL))
+            .unwrap_or_default();
+        self.respond(Response::GetWorkspacePosition {
+            x: pos.x1(),
+            y: pos.y1(),
+            width: pos.width(),
+            height: pos.height(),
+        });
+        Ok(())
+    }
+
     fn handle_window_exists(&self, window: Window) {
         self.respond(Response::WindowExists {
             exists: self.get_window(window).is_ok(),
@@ -3960,6 +3986,12 @@ impl ConfigProxyHandler {
             } => self
                 .handle_window_resize(window, dx1, dy1, dx2, dy2)
                 .wrn("window_resize")?,
+            ClientMessage::GetWindowPosition { window } => self
+                .handle_get_window_position(window)
+                .wrn("get_window_position")?,
+            ClientMessage::GetWorkspacePosition { workspace } => self
+                .handle_get_workspace_position(workspace)
+                .wrn("get_workspace_position")?,
             ClientMessage::SetSessionManagementEnabled { enabled } => {
                 self.handle_set_session_management_enabled(enabled)
             }


### PR DESCRIPTION
Adds `size` and `position` methods for windows and workspaces and for consistency a `size` method for outputs (`position` already exists here). 

This is useful to create screenshots, e.g.
```rust
fn screenshot_workspace(seat: Seat) {
    let ws = seat.get_workspace();
    if !ws.exists() {
        return;
    }
    let (x, y) = ws.position();
    let (w, h) = ws.size();
    screenshot_region(x, y, w, h);
}
```