### PR TITLE
Allow zwlr_foreign_toplevel_manager_v1 to move mouse to focused window

### DIFF
--- a/src/ifs/zwlr_foreign_toplevel_handle_v1.rs
+++ b/src/ifs/zwlr_foreign_toplevel_handle_v1.rs
@@ -75,6 +75,7 @@ impl ZwlrForeignToplevelHandleV1RequestHandler for ZwlrForeignToplevelHandleV1 {
             }
             let seat = self.client.lookup(req.seat)?;
             toplevel.node_do_focus_dyn(&seat.global, Direction::Unspecified);
+            seat.global.maybe_schedule_warp_mouse_to_focus();
         }
         Ok(())
     }


### PR DESCRIPTION
I've been experimenting with getting Noctalia's window switcher to function properly with Jay. Some people want the mouse to follow the selected/focused window and I've found this small patch allows it to happen if `unstable-mouse-follows-focus = true` is in the jay config.