### PR TITLE
config: add initial-layout option for workspaces

### DIFF
--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -82,6 +82,7 @@ use crate::window::WindowCriterion;
 use crate::window::WindowMatcher;
 use crate::window::WindowType;
 use crate::workspace::WorkspaceDisplayOrder;
+use crate::workspace::WorkspaceLayout;
 use crate::xwayland::XScalingMode;
 use bincode::Options;
 use futures_util::task::ArcWake;
@@ -2250,6 +2251,14 @@ impl ConfigClient {
             workspace,
             connector,
         });
+    }
+
+    pub fn set_workspace_initial_layout(
+        &self,
+        workspace: Workspace,
+        layout: Option<WorkspaceLayout>,
+    ) {
+        self.send(&ClientMessage::SetWorkspaceInitialLayout { workspace, layout });
     }
 
     pub fn parse_keymap_2(&self, builder: KeymapBuilder<'_>) -> Keymap {

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -54,6 +54,7 @@ use crate::window::Window;
 use crate::window::WindowMatcher;
 use crate::window::WindowType;
 use crate::workspace::WorkspaceDisplayOrder;
+use crate::workspace::WorkspaceLayout;
 use crate::xwayland::XScalingMode;
 use serde::Deserialize;
 use serde::Serialize;
@@ -1018,6 +1019,10 @@ pub enum ClientMessage<'a> {
         reuse: bool,
     },
     GetSplitReusesContainer,
+    SetWorkspaceInitialLayout {
+        workspace: Workspace,
+        layout: Option<WorkspaceLayout>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/jay-config/src/lib.rs
+++ b/jay-config/src/lib.rs
@@ -51,6 +51,7 @@ use crate::input::Seat;
 use crate::keyboard::ModifiedKeySym;
 use crate::video::Connector;
 use crate::window::Window;
+use crate::workspace::WorkspaceLayout;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt::Debug;
@@ -231,6 +232,14 @@ impl Workspace {
     /// be created on the connector set via this function, if possible.
     pub fn set_initial_connector(self, connector: Option<Connector>) {
         get!().set_workspace_initial_connector(self, connector);
+    }
+
+    /// Sets the layout that the root container of this workspace is initially created
+    /// with.
+    ///
+    /// If this is not set, the root container is created with a horizontal split.
+    pub fn set_initial_layout(self, layout: Option<WorkspaceLayout>) {
+        get!().set_workspace_initial_layout(self, layout);
     }
 
     /// Returns the position of the workspace in the global compositor space.

--- a/jay-config/src/workspace.rs
+++ b/jay-config/src/workspace.rs
@@ -18,3 +18,34 @@ pub enum WorkspaceDisplayOrder {
 pub fn set_workspace_display_order(order: WorkspaceDisplayOrder) {
     get!().set_workspace_display_order(order);
 }
+
+/// The layout that the root container of a workspace is initially created with.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum WorkspaceLayout {
+    /// The container is created in mono mode.
+    Mono,
+    /// The container is created in tiled mode.
+    Tile {
+        /// The direction in which the container is split.
+        direction: TileDirection,
+    },
+}
+
+/// The direction in which a tiled container is split.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum TileDirection {
+    /// The children are placed next to each other. This is the default.
+    Horizontal,
+    /// The children are placed on top of each other.
+    Vertical,
+    /// The children are placed along the larger dimension of the workspace.
+    ///
+    /// If the workspace is exactly as wide as it is high, this is the same as
+    /// `Horizontal`.
+    Major,
+    /// The children are placed along the smaller dimension of the workspace.
+    ///
+    /// If the workspace is exactly as wide as it is high, this is the same as
+    /// `Horizontal`.
+    Minor,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ use jay_config::keyboard::syms::KeySym;
 use jay_config::video::Connector;
 use jay_config::video::DrmDevice;
 use jay_config::window::{self};
+use jay_config::workspace::WorkspaceLayout;
 use libloading::Library;
 use std::cell::Cell;
 use std::mem;
@@ -210,6 +211,10 @@ impl ConfigProxy {
 
     pub fn initial_output_for_workspace(&self, name: &str) -> Option<Option<Rc<OutputNode>>> {
         self.handler.get()?.initial_output_for_workspace(name)
+    }
+
+    pub fn initial_layout_for_workspace(&self, name: &str) -> Option<WorkspaceLayout> {
+        self.handler.get()?.initial_layout_for_workspace(name)
     }
 
     pub fn update_capabilities(

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -151,6 +151,7 @@ use jay_config::window::TileState as ConfigTileState;
 use jay_config::window::Window;
 use jay_config::window::WindowMatcher;
 use jay_config::workspace::WorkspaceDisplayOrder;
+use jay_config::workspace::WorkspaceLayout;
 use jay_config::xwayland::XScalingMode;
 use kbvm::GroupIndex;
 use kbvm::Keycode;
@@ -239,6 +240,7 @@ pub struct ConfigWorkspace {
     name: String,
     ty: Cell<WorkspaceType>,
     initial_connector: Cell<Option<Connector>>,
+    initial_layout: Cell<Option<WorkspaceLayout>>,
 }
 
 pub struct Pollable {
@@ -331,6 +333,7 @@ impl ConfigProxyHandler {
                     name: name.to_string(),
                     ty: Cell::new(ty),
                     initial_connector: Default::default(),
+                    initial_layout: Default::default(),
                 });
                 self.workspaces_by_name.set(name.clone(), ws.clone());
                 self.workspaces_by_id.set(id, ws);
@@ -3319,6 +3322,16 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
+    fn handle_set_workspace_initial_layout(
+        &self,
+        workspace: Workspace,
+        layout: Option<WorkspaceLayout>,
+    ) -> Result<(), CphError> {
+        let ws = self.get_workspace(workspace)?;
+        ws.initial_layout.set(layout);
+        Ok(())
+    }
+
     pub fn handle_request(self: &Rc<Self>, msg: &[u8]) {
         if let Err(e) = self.handle_request_(msg) {
             log::error!("Could not handle client request: {}", ErrorFmt(e));
@@ -4089,6 +4102,9 @@ impl ConfigProxyHandler {
             ClientMessage::GetPlaneColorPipelinesEnabled { device } => self
                 .handle_get_plane_color_pipelines_enabled(device)
                 .wrn("get_plane_color_pipelines_enabled")?,
+            ClientMessage::SetWorkspaceInitialLayout { workspace, layout } => self
+                .handle_set_workspace_initial_layout(workspace, layout)
+                .wrn("set_workspace_initial_layout")?,
         }
         Ok(())
     }
@@ -4115,6 +4131,10 @@ impl ConfigProxyHandler {
         let ws = self.workspaces_by_name.get(name)?;
         let connector = ws.initial_connector.get()?;
         Some(self.get_output_node(connector).ok())
+    }
+
+    pub fn initial_layout_for_workspace(&self, name: &str) -> Option<WorkspaceLayout> {
+        self.workspaces_by_name.get(name)?.initial_layout.get()
     }
 
     pub fn update_capabilities(

--- a/src/ifs/wl_seat/pointer_owner.rs
+++ b/src/ifs/wl_seat/pointer_owner.rs
@@ -24,7 +24,6 @@ use crate::ifs::xdg_toplevel_drag_v1::XdgToplevelDragV1;
 use crate::rect::Rect;
 use crate::time::Time;
 use crate::tree::ContainerNode;
-use crate::tree::ContainerSplit;
 use crate::tree::ContainingNode;
 use crate::tree::FindTreeUsecase;
 use crate::tree::FoundNode;
@@ -1594,13 +1593,8 @@ impl UiDragUsecase for TileDragUsecase {
         };
         let new_container = |workspace: &Rc<WorkspaceNode>| {
             src_parent.clone().cnode_remove_child2(&*src, true);
-            let cn = ContainerNode::new(
-                &seat.state,
-                &workspace,
-                src.clone(),
-                ContainerSplit::Horizontal,
-            );
-            workspace.set_container(&cn);
+            seat.state
+                .create_workspace_container(workspace, src.clone());
         };
         match dest {
             TddType::Replace(dst) => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -248,6 +248,8 @@ use crate::xwayland::{self};
 use bstr::ByteSlice;
 use isnt::std_1::primitive::IsntSliceExt;
 use jay_config::PciId;
+use jay_config::workspace::TileDirection;
+use jay_config::workspace::WorkspaceLayout;
 use linearize::StaticCopyMap;
 use linearize::StaticMap;
 use std::cell::Cell;
@@ -1171,9 +1173,37 @@ impl State {
                 c.append_child(node);
             }
         } else {
-            let container = ContainerNode::new(self, ws, node, ContainerSplit::Horizontal);
-            ws.set_container(&container);
+            self.create_workspace_container(ws, node);
         }
+    }
+
+    /// Creates the root container of `ws` with the initial layout configured for `ws`.
+    pub fn create_workspace_container(
+        self: &Rc<Self>,
+        ws: &Rc<WorkspaceNode>,
+        node: Rc<dyn ToplevelNode>,
+    ) -> Rc<ContainerNode> {
+        let layout = self
+            .config
+            .get()
+            .and_then(|c| c.initial_layout_for_workspace(&ws.name));
+        let pos = ws.node_state[LiveTL].position.get();
+        let split = match layout {
+            Some(WorkspaceLayout::Tile { direction }) => match direction {
+                TileDirection::Horizontal => ContainerSplit::Horizontal,
+                TileDirection::Vertical => ContainerSplit::Vertical,
+                TileDirection::Major if pos.height() > pos.width() => ContainerSplit::Vertical,
+                TileDirection::Minor if pos.width() > pos.height() => ContainerSplit::Vertical,
+                TileDirection::Major | TileDirection::Minor => ContainerSplit::Horizontal,
+            },
+            Some(WorkspaceLayout::Mono) | None => ContainerSplit::Horizontal,
+        };
+        let container = ContainerNode::new(self, ws, node.clone(), split);
+        ws.set_container(&container);
+        if layout == Some(WorkspaceLayout::Mono) {
+            container.set_mono(Some(&*node));
+        }
+        container
     }
 
     pub fn map_floating(

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -64,6 +64,7 @@ use jay_config::window::ContentType;
 use jay_config::window::TileState;
 use jay_config::window::WindowType;
 use jay_config::workspace::WorkspaceDisplayOrder;
+use jay_config::workspace::WorkspaceLayout;
 use jay_config::xwayland::XScalingMode;
 use std::cell::Cell;
 use std::cell::RefCell;
@@ -250,6 +251,7 @@ pub struct TomlWorkspace {
     pub _ty: WorkspaceType,
     pub output: Option<Rc<OutputMatch>>,
     pub output_matched: Cell<Option<Connector>>,
+    pub layout: Option<WorkspaceLayout>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/toml-config/src/config/parsers.rs
+++ b/toml-config/src/config/parsers.rs
@@ -64,6 +64,7 @@ mod window_rule;
 mod window_type;
 pub mod workspace;
 mod workspace_display_order;
+mod workspace_layout;
 mod xwayland;
 
 #[derive(Debug, Error)]

--- a/toml-config/src/config/parsers/workspace.rs
+++ b/toml-config/src/config/parsers/workspace.rs
@@ -13,6 +13,7 @@ use crate::config::parser::ParseResult;
 use crate::config::parser::Parser;
 use crate::config::parser::UnexpectedDataType;
 use crate::config::parsers::output_match::OutputMatchParser;
+use crate::config::parsers::workspace_layout::WorkspaceLayoutParser;
 use crate::toml::toml_span::Span;
 use crate::toml::toml_span::Spanned;
 use crate::toml::toml_value::Value;
@@ -21,6 +22,7 @@ use indexmap::IndexMap;
 use jay_config::Workspace;
 use jay_config::video::Connector;
 use jay_config::video::connectors;
+use jay_config::workspace::WorkspaceLayout;
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
@@ -35,6 +37,7 @@ pub struct WorkspaceSlot {
     pub explicit_ty: Cell<Option<WorkspaceType>>,
     pub implicit_output: RefCell<Option<Rc<OutputMatch>>>,
     pub explicit_output: RefCell<Option<Rc<OutputMatch>>>,
+    pub explicit_layout: Cell<Option<WorkspaceLayout>>,
 }
 
 impl WorkspaceSlot {
@@ -48,6 +51,7 @@ impl WorkspaceSlot {
                 .clone()
                 .or(self.implicit_output.borrow().clone()),
             output_matched: Default::default(),
+            layout: self.explicit_layout.get(),
         }
     }
 }
@@ -103,6 +107,18 @@ impl TomlWorkspace {
             wwio.remove(&self.ws);
         }
     }
+
+    pub fn apply_initial_layout(&self, state: &State) {
+        let Some(layout) = self.layout else {
+            return;
+        };
+        self.ws.set_initial_layout(Some(layout));
+        state
+            .persistent
+            .workspaces_with_initial_layouts
+            .borrow_mut()
+            .insert(self.ws);
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -123,6 +139,7 @@ impl Context<'_, '_> {
             explicit_ty: Default::default(),
             implicit_output: Default::default(),
             explicit_output: Default::default(),
+            explicit_layout: Default::default(),
         });
         map.insert(name.to_string(), ws.clone());
         ws
@@ -191,8 +208,11 @@ impl Parser for WorkspaceParser<'_, '_, '_> {
         table: &IndexMap<Spanned<String>, Spanned<Value>>,
     ) -> ParseResult<Self> {
         let mut ext = Extractor::new(self.cx, span, table);
-        let (ty_str, initial_output) =
-            ext.extract((recover(opt(str("type"))), opt(val("initial-output"))))?;
+        let (ty_str, initial_output, initial_layout) = ext.extract((
+            recover(opt(str("type"))),
+            opt(val("initial-output")),
+            opt(val("initial-layout")),
+        ))?;
         let ws = self.cx.get_workspace_slot(self.name);
         if let Some(v) = initial_output {
             match v.parse(&mut OutputMatchParser(self.cx)) {
@@ -213,6 +233,14 @@ impl Parser for WorkspaceParser<'_, '_, '_> {
                     }
                 };
                 ws.explicit_ty.set(Some(ty));
+            }
+        }
+        if let Some(v) = initial_layout {
+            match v.parse(&mut WorkspaceLayoutParser(self.cx)) {
+                Ok(v) => ws.explicit_layout.set(Some(v)),
+                Err(e) => {
+                    log::error!("Could not parse initial layout: {}", self.cx.error(e));
+                }
             }
         }
         Ok(())

--- a/toml-config/src/config/parsers/workspace_layout.rs
+++ b/toml-config/src/config/parsers/workspace_layout.rs
@@ -1,0 +1,74 @@
+use crate::config::context::Context;
+use crate::config::extractor::Extractor;
+use crate::config::extractor::ExtractorError;
+use crate::config::extractor::opt;
+use crate::config::extractor::str;
+use crate::config::parser::DataType;
+use crate::config::parser::ParseResult;
+use crate::config::parser::Parser;
+use crate::config::parser::UnexpectedDataType;
+use crate::toml::toml_span::Span;
+use crate::toml::toml_span::Spanned;
+use crate::toml::toml_span::SpannedExt;
+use crate::toml::toml_value::Value;
+use indexmap::IndexMap;
+use jay_config::workspace::TileDirection;
+use jay_config::workspace::WorkspaceLayout;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum WorkspaceLayoutParserError {
+    #[error(transparent)]
+    Expected(#[from] UnexpectedDataType),
+    #[error(transparent)]
+    Extract(#[from] ExtractorError),
+    #[error("Unknown layout type {0}")]
+    UnknownType(String),
+    #[error("Unknown tile direction {0}")]
+    UnknownDirection(String),
+}
+
+pub struct WorkspaceLayoutParser<'a, 'b, 'c>(pub &'a Context<'b, 'c>);
+
+impl Parser for WorkspaceLayoutParser<'_, '_, '_> {
+    type Value = WorkspaceLayout;
+    type Error = WorkspaceLayoutParserError;
+    const EXPECTED: &'static [DataType] = &[DataType::Table];
+
+    fn parse_table(
+        &mut self,
+        span: Span,
+        table: &IndexMap<Spanned<String>, Spanned<Value>>,
+    ) -> ParseResult<Self> {
+        let mut ext = Extractor::new(self.0, span, table);
+        let ty = ext.extract_or_ignore(str("type"))?;
+        let layout = match ty.value {
+            "mono" => WorkspaceLayout::Mono,
+            "tile" => {
+                let direction = ext.extract(opt(str("direction")))?;
+                let direction = match direction {
+                    None => TileDirection::Horizontal,
+                    Some(d) => match d.value {
+                        "horizontal" => TileDirection::Horizontal,
+                        "vertical" => TileDirection::Vertical,
+                        "major" => TileDirection::Major,
+                        "minor" => TileDirection::Minor,
+                        _ => {
+                            return Err(WorkspaceLayoutParserError::UnknownDirection(
+                                d.value.to_owned(),
+                            )
+                            .spanned(d.span));
+                        }
+                    },
+                };
+                WorkspaceLayout::Tile { direction }
+            }
+            _ => {
+                return Err(
+                    WorkspaceLayoutParserError::UnknownType(ty.value.to_owned()).spanned(ty.span)
+                );
+            }
+        };
+        Ok(layout)
+    }
+}

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -1309,6 +1309,7 @@ struct PersistentState {
     workspaces_with_initial_outputs: RefCell<AHashSet<Workspace>>,
     triggers: RefCell<Vec<Rc<TomlTrigger>>>,
     counters: RefCell<Vec<Rc<Counter>>>,
+    workspaces_with_initial_layouts: RefCell<AHashSet<Workspace>>,
 }
 
 async fn watch_config(persistent: Rc<PersistentState>) {
@@ -1546,6 +1547,13 @@ fn load_config(initial_load: bool, auto_reload: bool, persistent: &Rc<Persistent
         .drain()
     {
         ws.set_initial_connector(None);
+    }
+    for ws in persistent
+        .workspaces_with_initial_layouts
+        .borrow_mut()
+        .drain()
+    {
+        ws.set_initial_layout(None);
     }
     if let Some(auto_reload) = config.auto_reload {
         if auto_reload {
@@ -1813,6 +1821,7 @@ fn load_config(initial_load: bool, auto_reload: bool, persistent: &Rc<Persistent
     }
     for ws in &state.workspaces {
         ws.determine_initial_output2(&state, &connectors);
+        ws.apply_initial_layout(&state);
     }
     for c in jay_config::input::input_devices() {
         state.add_io_input(c);
@@ -1977,6 +1986,7 @@ pub fn configure() {
         workspaces_with_initial_outputs: Default::default(),
         triggers: Default::default(),
         counters: Default::default(),
+        workspaces_with_initial_layouts: Default::default(),
     });
     {
         let p = persistent.clone();

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -2543,6 +2543,16 @@
       },
       "required": []
     },
+    "TileDirection": {
+      "type": "string",
+      "description": "The direction in which a tiled container is split.\n",
+      "enum": [
+        "horizontal",
+        "vertical",
+        "major",
+        "minor"
+      ]
+    },
     "TileState": {
       "type": "string",
       "description": "Whether a window is tiled or floating.",
@@ -2999,6 +3009,10 @@
         "initial-output": {
           "description": "The initial output of the workspace.\n\nThis setting can be overwritten with the `output` field in `show-workspace`\nactions. If that field is not used or the workspace is created via some other\nmechanism, it will be created on the output set via this setting, if possible.\n\nIf the matcher matches multiple outputs, the selected output is undefined.\n\nIf this setting is not used, then the initial output will be inferred from the\noutput set in a `show-workspace` action, if possible.\n",
           "$ref": "#/$defs/OutputMatch"
+        },
+        "initial-layout": {
+          "description": "The initial layout of the root container of the workspace.\n\nThis determines how the first windows on the workspace are tiled. Once the\nroot container exists, its layout can be changed as usual and this setting\nhas no further effect.\n\nThe default is `{ type = \"tile\" }`.\n",
+          "$ref": "#/$defs/WorkspaceLayout"
         }
       },
       "required": []
@@ -3009,6 +3023,39 @@
       "enum": [
         "manual",
         "sorted"
+      ]
+    },
+    "WorkspaceLayout": {
+      "description": "The initial layout of the root container of a workspace.\n",
+      "anyOf": [
+        {
+          "description": "The container is created in tiled mode.\n\n- Example:\n\n  ```toml\n  [workspaces.\"1\"]\n  initial-layout = { type = \"tile\", direction = \"major\" }\n  ```\n",
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "tile"
+            },
+            "direction": {
+              "description": "The direction in which the container is split.\n\nThe default is `horizontal`.\n",
+              "$ref": "#/$defs/TileDirection"
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "description": "The container is created in mono mode.\n\n- Example:\n\n  ```toml\n  [workspaces.\"1\"]\n  initial-layout = { type = \"mono\" }\n  ```\n",
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "mono"
+            }
+          },
+          "required": [
+            "type"
+          ]
+        }
       ]
     },
     "WorkspaceType": {

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -5609,6 +5609,37 @@ The table has the following fields:
   The value of this field should be a [ContainerBorders](#types-ContainerBorders).
 
 
+<a name="types-TileDirection"></a>
+### `TileDirection`
+
+The direction in which a tiled container is split.
+
+Values of this type should be strings.
+
+The string should have one of the following values:
+
+- `horizontal`:
+
+  The children are placed next to each other. This is the default.
+
+- `vertical`:
+
+  The children are placed on top of each other.
+
+- `major`:
+
+  The children are placed along the larger dimension of the workspace. That is,
+  on top of each other if the workspace is higher than it is wide and next to
+  each other otherwise.
+
+- `minor`:
+
+  The children are placed along the smaller dimension of the workspace. That is,
+  on top of each other if the workspace is wider than it is high and next to
+  each other otherwise.
+
+
+
 <a name="types-TileState"></a>
 ### `TileState`
 
@@ -6521,6 +6552,18 @@ The table has the following fields:
 
   The value of this field should be a [OutputMatch](#types-OutputMatch).
 
+- `initial-layout` (optional):
+
+  The initial layout of the root container of the workspace.
+  
+  This determines how the first windows on the workspace are tiled. Once the
+  root container exists, its layout can be changed as usual and this setting
+  has no further effect.
+  
+  The default is `{ type = "tile" }`.
+
+  The value of this field should be a [WorkspaceLayout](#types-WorkspaceLayout).
+
 
 <a name="types-WorkspaceDisplayOrder"></a>
 ### `WorkspaceDisplayOrder`
@@ -6539,6 +6582,50 @@ The string should have one of the following values:
 
   Workspaces are sorted using natural ordering and cannot be manually dragged.
 
+
+
+<a name="types-WorkspaceLayout"></a>
+### `WorkspaceLayout`
+
+The initial layout of the root container of a workspace.
+
+Values of this type should be tables.
+
+This table is a tagged union. The variant is determined by the `type` field. It takes one of the following values:
+
+- `tile`:
+
+  The container is created in tiled mode.
+  
+  - Example:
+  
+    ```toml
+    [workspaces."1"]
+    initial-layout = { type = "tile", direction = "major" }
+    ```
+
+  The table has the following fields:
+
+  - `direction` (optional):
+
+    The direction in which the container is split.
+    
+    The default is `horizontal`.
+
+    The value of this field should be a [TileDirection](#types-TileDirection).
+
+- `mono`:
+
+  The container is created in mono mode.
+  
+  - Example:
+  
+    ```toml
+    [workspaces."1"]
+    initial-layout = { type = "mono" }
+    ```
+
+  The table has no fields.
 
 
 <a name="types-WorkspaceType"></a>

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -5110,6 +5110,74 @@ Workspace:
 
         If this setting is not used, then the initial output will be inferred from the
         output set in a `show-workspace` action, if possible.
+    initial-layout:
+      ref: WorkspaceLayout
+      required: false
+      description: |
+        The initial layout of the root container of the workspace.
+
+        This determines how the first windows on the workspace are tiled. Once the
+        root container exists, its layout can be changed as usual and this setting
+        has no further effect.
+
+        The default is `{ type = "tile" }`.
+
+
+WorkspaceLayout:
+  description: |
+    The initial layout of the root container of a workspace.
+  kind: table
+  types:
+    tile:
+      description: |
+        The container is created in tiled mode.
+
+        - Example:
+
+          ```toml
+          [workspaces."1"]
+          initial-layout = { type = "tile", direction = "major" }
+          ```
+      fields:
+        direction:
+          ref: TileDirection
+          required: false
+          description: |
+            The direction in which the container is split.
+
+            The default is `horizontal`.
+    mono:
+      description: |
+        The container is created in mono mode.
+
+        - Example:
+
+          ```toml
+          [workspaces."1"]
+          initial-layout = { type = "mono" }
+          ```
+      fields: {}
+
+
+TileDirection:
+  description: |
+    The direction in which a tiled container is split.
+  kind: string
+  values:
+    - value: horizontal
+      description: The children are placed next to each other. This is the default.
+    - value: vertical
+      description: The children are placed on top of each other.
+    - value: major
+      description: |
+        The children are placed along the larger dimension of the workspace. That is,
+        on top of each other if the workspace is higher than it is wide and next to
+        each other otherwise.
+    - value: minor
+      description: |
+        The children are placed along the smaller dimension of the workspace. That is,
+        on top of each other if the workspace is wider than it is high and next to
+        each other otherwise.
 
 
 WorkspaceType:

--- a/toml-spec/src/markdown.rs
+++ b/toml-spec/src/markdown.rs
@@ -135,6 +135,11 @@ fn write_variant_spec(buf: &mut Vec<u8>, spec: &VariantSpec) -> Result<()> {
 }
 
 fn write_single_table_spec(buf: &mut Vec<u8>, spec: &SingleTableSpec, pad: &str) -> Result<()> {
+    if spec.fields.is_empty() {
+        writeln!(buf, "{pad}The table has no fields.")?;
+        writeln!(buf)?;
+        return Ok(());
+    }
     writeln!(buf, "{pad}The table has the following fields:")?;
     writeln!(buf)?;
     for (name, fs) in &spec.fields {


### PR DESCRIPTION
Implements https://github.com/mahkoh/jay/issues/1077 per workspace.

Allows to configure the initial layout (`mono` / `tile`) and for tiled layout the split direction (`horizontal` / `vertical` / `major` / `minor`) per workspace.  
`major` splits along the workspace's longer axis and `minor` along its shorter one, based on the ratio of workspace width to height. This makes it possible to split dynamically vertically on vertical outputs without configuring `initial-output`.
If the initial layout or split direction is not configured, the current default of splitting horizontally is preserved. 

This option is designed extendable to account for future layout options, e.g. `dwindle` for auto tiling as proposed in https://github.com/mahkoh/jay/issues/641.

Finally, since `mono` appears to be the first table without fields, toml-spec is extended to account for this.