### PR TITLE
config: add is-root-container window match rule

### DIFF
--- a/book/src/control-center.md
+++ b/book/src/control-center.md
@@ -605,6 +605,9 @@ Urgent
 Fullscreen
 : Whether the window is fullscreen
 
+Workspace Container
+: Whether the window is the outermost container of a workspace
+
 Content Type
 : The content type hint (photo, video, game), if set
 
@@ -673,8 +676,9 @@ Instance ID (all regex-matched text fields with a "Regex" checkbox), Sandboxed,
 Is Xwayland (boolean), UID, PID (numeric inputs).
 
 **Window criteria:** Title, App ID, Tag, Workspace, X Class, X Instance, X Role
-(all regex-matched text fields), Floating, Visible, Urgent, Fullscreen
-(boolean), Content Types (checkboxes for Photo, Video, Game), and **Client**
+(all regex-matched text fields), Floating, Visible, Urgent, Fullscreen,
+Workspace Container (boolean), Content Types (checkboxes for Photo, Video,
+Game), and **Client**
 (a nested client criterion builder for filtering by the owning client's
 properties).
 

--- a/book/src/window-rules.md
+++ b/book/src/window-rules.md
@@ -284,6 +284,11 @@ client-created windows (XDG toplevels and X windows).
 `just-mapped`
 : `true` for one compositor iteration after the window maps.
 
+`is-workspace-container`
+: Whether the window is the container of a workspace -- the outermost container,
+  whose parent is the workspace itself. It is created when the first window is
+  tiled on that workspace. Only containers can match this.
+
 `tag` / `tag-regex`
 : The XDG toplevel tag.
 

--- a/jay-config/src/_private.rs
+++ b/jay-config/src/_private.rs
@@ -132,6 +132,7 @@ pub enum WindowCriterionIpc {
     JustMapped,
     Workspace(Workspace),
     ContentTypes(ContentType),
+    IsWorkspaceContainer,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -2149,6 +2149,7 @@ impl ConfigClient {
             WindowCriterion::Focus(seat) => WindowCriterionIpc::SeatFocus(seat),
             WindowCriterion::Fullscreen => WindowCriterionIpc::Fullscreen,
             WindowCriterion::JustMapped => WindowCriterionIpc::JustMapped,
+            WindowCriterion::IsWorkspaceContainer => WindowCriterionIpc::IsWorkspaceContainer,
             WindowCriterion::Tag(t) => string!(t, Tag, false),
             WindowCriterion::TagRegex(t) => string!(t, Tag, true),
             WindowCriterion::XClass(t) => string!(t, XClass, false),

--- a/jay-config/src/window.rs
+++ b/jay-config/src/window.rs
@@ -339,6 +339,8 @@ pub enum WindowCriterion<'a> {
     WorkspaceNameRegex(&'a str),
     /// Matches if the window has one of the content types.
     ContentTypes(ContentType),
+    /// Matches if the window is the root container of a workspace.
+    IsWorkspaceContainer,
 }
 
 impl WindowCriterion<'_> {

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -2664,6 +2664,7 @@ impl ConfigProxyHandler {
             WindowCriterionIpc::SeatFocus(seat) => mgr.seat_focus(&*self.get_seat(*seat)?),
             WindowCriterionIpc::Fullscreen => mgr.fullscreen(),
             WindowCriterionIpc::JustMapped => mgr.just_mapped(),
+            WindowCriterionIpc::IsWorkspaceContainer => mgr.is_workspace_container(),
             WindowCriterionIpc::Workspace(w) => mgr.workspace(CritLiteralOrRegex::Literal(
                 self.get_workspace(*w)?.name.clone(),
             )),

--- a/src/control_center/cc_window.rs
+++ b/src/control_center/cc_window.rs
@@ -56,6 +56,7 @@ enum WindowCrit {
     Visible,
     Urgent,
     Fullscreen,
+    WorkspaceContainer,
     Tag(CritRegex),
     XClass(CritRegex),
     XInstance(CritRegex),
@@ -73,6 +74,7 @@ enum WindowCritTy {
     Visible,
     Urgent,
     Fullscreen,
+    WorkspaceContainer,
     Tag,
     XClass,
     XInstance,
@@ -91,6 +93,7 @@ impl StaticText for WindowCritTy {
             WindowCritTy::Visible => "Visible",
             WindowCritTy::Urgent => "Urgent",
             WindowCritTy::Fullscreen => "Fullscreen",
+            WindowCritTy::WorkspaceContainer => "Workspace Container",
             WindowCritTy::Tag => "Tag",
             WindowCritTy::XClass => "X Class",
             WindowCritTy::XInstance => "X Instance",
@@ -123,6 +126,7 @@ impl CritImpl for WindowCrit {
             Visible,
             Urgent,
             Fullscreen,
+            WorkspaceContainer,
             Tag,
             XClass,
             XInstance,
@@ -141,6 +145,7 @@ impl CritImpl for WindowCrit {
             WindowCritTy::Visible => Self::Visible,
             WindowCritTy::Urgent => Self::Urgent,
             WindowCritTy::Fullscreen => Self::Fullscreen,
+            WindowCritTy::WorkspaceContainer => Self::WorkspaceContainer,
             WindowCritTy::Tag => Self::Tag(Default::default()),
             WindowCritTy::XClass => Self::XClass(Default::default()),
             WindowCritTy::XInstance => Self::XInstance(Default::default()),
@@ -161,6 +166,7 @@ impl CritImpl for WindowCrit {
             WindowCrit::Visible => false,
             WindowCrit::Urgent => false,
             WindowCrit::Fullscreen => false,
+            WindowCrit::WorkspaceContainer => false,
             WindowCrit::Tag(v) => v.show(ui),
             WindowCrit::XClass(v) => v.show(ui),
             WindowCrit::XInstance(v) => v.show(ui),
@@ -180,6 +186,7 @@ impl CritImpl for WindowCrit {
             WindowCrit::Visible => m.visible(),
             WindowCrit::Urgent => m.urgent(),
             WindowCrit::Fullscreen => m.fullscreen(),
+            WindowCrit::WorkspaceContainer => m.is_workspace_container(),
             WindowCrit::Tag(v) => m.tag(v.to_crit()?),
             WindowCrit::XClass(v) => m.class(v.to_crit()?),
             WindowCrit::XInstance(v) => m.instance(v.to_crit()?),
@@ -408,6 +415,11 @@ pub fn show_window(behavior: &mut CcBehavior<'_>, ui: &mut Ui, window: &dyn Topl
         read_only_bool(ui, "Visible", data.visible[LiveTL].get());
         read_only_bool(ui, "Urgent", data.wants_attention.get());
         read_only_bool(ui, "Fullscreen", data.is_fullscreen[LiveTL].get());
+        read_only_bool(
+            ui,
+            "Workspace Container",
+            data.is_root_container[LiveTL].get(),
+        );
         if let Some(ct) = data.content_type.get() {
             label(ui, "Content Type", ct.text());
         }

--- a/src/criteria/tlm.rs
+++ b/src/criteria/tlm.rs
@@ -22,6 +22,7 @@ use crate::criteria::tlm::tlm_matchers::tlmm_client::TlmMatchClient;
 use crate::criteria::tlm::tlm_matchers::tlmm_content_type::TlmMatchContentType;
 use crate::criteria::tlm::tlm_matchers::tlmm_floating::TlmMatchFloating;
 use crate::criteria::tlm::tlm_matchers::tlmm_fullscreen::TlmMatchFullscreen;
+use crate::criteria::tlm::tlm_matchers::tlmm_is_workspace_container::TlmMatchIsWorkspaceContainer;
 use crate::criteria::tlm::tlm_matchers::tlmm_just_mapped::TlmMatchJustMapped;
 use crate::criteria::tlm::tlm_matchers::tlmm_kind::TlmMatchKind;
 use crate::criteria::tlm::tlm_matchers::tlmm_seat_focus::TlmMatchSeatFocus;
@@ -67,6 +68,7 @@ bitflags! {
     TL_CHANGED_ROLE,
     TL_CHANGED_WORKSPACE,
     TL_CHANGED_CONTENT_TY,
+    TL_CHANGED_IS_WORKSPACE_CONTAINER,
 }
 
 type TlmFixedRootMatcher<T> = FixedRootMatcher<ToplevelData, T>;
@@ -82,6 +84,7 @@ pub struct TlMatcherManager {
     urgent: TlmFixedRootMatcher<TlmMatchUrgent>,
     fullscreen: TlmFixedRootMatcher<TlmMatchFullscreen>,
     just_mapped: TlmFixedRootMatcher<TlmMatchJustMapped>,
+    is_workspace_container: TlmFixedRootMatcher<TlmMatchIsWorkspaceContainer>,
     matchers: Rc<RootMatchers>,
 }
 
@@ -170,6 +173,7 @@ impl TlMatcherManager {
             urgent: bool!(TlmMatchUrgent),
             fullscreen: bool!(TlmMatchFullscreen),
             just_mapped: bool!(TlmMatchJustMapped),
+            is_workspace_container: bool!(TlmMatchIsWorkspaceContainer),
             changes: Default::default(),
             leaf_events: Default::default(),
             ids: ids.clone(),
@@ -188,6 +192,7 @@ impl TlMatcherManager {
         self.urgent.values().for_each(|c| c.clear());
         self.fullscreen.values().for_each(|c| c.clear());
         self.just_mapped.values().for_each(|c| c.clear());
+        self.is_workspace_container.values().for_each(|c| c.clear());
         self.matchers.clear();
     }
 
@@ -261,6 +266,7 @@ impl TlMatcherManager {
         fixed_conditional!(TL_CHANGED_URGENT, urgent);
         fixed_conditional!(TL_CHANGED_FULLSCREEN, fullscreen);
         fixed_conditional!(TL_CHANGED_JUST_MAPPED, just_mapped);
+        fixed_conditional!(TL_CHANGED_IS_WORKSPACE_CONTAINER, is_workspace_container);
         false
     }
 
@@ -339,6 +345,7 @@ impl TlMatcherManager {
         fixed_conditional!(TL_CHANGED_URGENT, urgent);
         fixed_conditional!(TL_CHANGED_FULLSCREEN, fullscreen);
         fixed_conditional!(TL_CHANGED_JUST_MAPPED, just_mapped);
+        fixed_conditional!(TL_CHANGED_IS_WORKSPACE_CONTAINER, is_workspace_container);
         if changed.contains(TL_CHANGED_JUST_MAPPED)
             && data.just_mapped()
             && (self.just_mapped[false].has_downstream() || self.just_mapped[true].has_downstream())
@@ -386,6 +393,10 @@ impl TlMatcherManager {
 
     pub fn just_mapped(&self) -> Rc<TlmUpstreamNode> {
         self.just_mapped[true].clone()
+    }
+
+    pub fn is_workspace_container(&self) -> Rc<TlmUpstreamNode> {
+        self.is_workspace_container[true].clone()
     }
 
     pub fn seat_focus(&self, seat: &WlSeatGlobal) -> Rc<TlmUpstreamNode> {

--- a/src/criteria/tlm/tlm_matchers.rs
+++ b/src/criteria/tlm/tlm_matchers.rs
@@ -21,6 +21,7 @@ pub mod tlmm_client;
 pub mod tlmm_content_type;
 pub mod tlmm_floating;
 pub mod tlmm_fullscreen;
+pub mod tlmm_is_workspace_container;
 pub mod tlmm_just_mapped;
 pub mod tlmm_kind;
 pub mod tlmm_seat_focus;

--- a/src/criteria/tlm/tlm_matchers/tlmm_is_workspace_container.rs
+++ b/src/criteria/tlm/tlm_matchers/tlmm_is_workspace_container.rs
@@ -1,0 +1,13 @@
+use crate::criteria::crit_graph::CritFixedRootCriterion;
+use crate::tree::ToplevelData;
+use crate::tree::TreeTimeline::LiveTL;
+
+pub struct TlmMatchIsWorkspaceContainer(pub bool);
+
+fixed_root_criterion!(TlmMatchIsWorkspaceContainer, is_workspace_container);
+
+impl CritFixedRootCriterion<ToplevelData> for TlmMatchIsWorkspaceContainer {
+    fn matches(&self, data: &ToplevelData) -> bool {
+        data.is_root_container[LiveTL].get()
+    }
+}

--- a/src/ifs/jay_compositor.rs
+++ b/src/ifs/jay_compositor.rs
@@ -95,7 +95,7 @@ global_base!(JayCompositorGlobal, JayCompositor, JayCompositorError);
 
 impl Global for JayCompositorGlobal {
     fn version(&self) -> u32 {
-        42
+        43
     }
 
     fn required_caps(&self) -> ClientCaps {

--- a/src/ifs/jay_window_match_builder.rs
+++ b/src/ifs/jay_window_match_builder.rs
@@ -137,6 +137,14 @@ impl JayWindowMatchBuilderRequestHandler for JayWindowMatchBuilder {
             .push(self.builder.mgr.content_type(ContentType(req.v)));
         Ok(())
     }
+
+    fn is_workspace_container(
+        &self,
+        _req: IsWorkspaceContainer,
+        _slf: &Rc<Self>,
+    ) -> Result<(), Self::Error> {
+        push_bool!(self, is_workspace_container)
+    }
 }
 
 object_base! {

--- a/src/tools/tool_client.rs
+++ b/src/tools/tool_client.rs
@@ -376,7 +376,7 @@ impl ToolClient {
             self_id: s.registry,
             name: s.jay_compositor.0,
             interface: JayCompositor.name(),
-            version: s.jay_compositor.1.min(42),
+            version: s.jay_compositor.1.min(43),
             id: id.into(),
         });
         self.jay_compositor.set(Some(id));
@@ -802,6 +802,7 @@ impl ToolClient {
             workspace,
             workspace_regex,
             content_types,
+            is_workspace_container,
         } = m;
 
         self.generic_match(gmb, generic, |m| {
@@ -826,6 +827,7 @@ impl ToolClient {
         bool!(focused, Focused);
         bool!(fullscreen, Fullscreen);
         bool!(just_mapped, JustMapped);
+        bool!(is_workspace_container, IsWorkspaceContainer);
         num2!(types, Types);
         num2!(content_types, ContentTypes);
     }

--- a/src/tree/toplevel.rs
+++ b/src/tree/toplevel.rs
@@ -7,6 +7,7 @@ use crate::criteria::tlm::TL_CHANGED_CONTENT_TY;
 use crate::criteria::tlm::TL_CHANGED_DESTROYED;
 use crate::criteria::tlm::TL_CHANGED_FLOATING;
 use crate::criteria::tlm::TL_CHANGED_FULLSCREEN;
+use crate::criteria::tlm::TL_CHANGED_IS_WORKSPACE_CONTAINER;
 use crate::criteria::tlm::TL_CHANGED_NEW;
 use crate::criteria::tlm::TL_CHANGED_TITLE;
 use crate::criteria::tlm::TL_CHANGED_URGENT;
@@ -1097,12 +1098,13 @@ impl ToplevelData {
     }
 
     pub fn set_is_root_container(&self, value: bool) {
-        if self.is_root_container[LiveTL].replace(value) != value
-            && let Some(slf) = self.slf.upgrade()
-        {
-            slf.clone()
-                .tl_schedule_data_op(ToplevelDataTransactionOp::SetIsRootContainer(value));
-            slf.tl_is_root_container_changed();
+        if self.is_root_container[LiveTL].replace(value) != value {
+            self.property_changed(TL_CHANGED_IS_WORKSPACE_CONTAINER);
+            if let Some(slf) = self.slf.upgrade() {
+                slf.clone()
+                    .tl_schedule_data_op(ToplevelDataTransactionOp::SetIsRootContainer(value));
+                slf.tl_is_root_container_changed();
+            }
         }
     }
 

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -396,6 +396,7 @@ pub struct WindowMatch {
     pub workspace: Option<String>,
     pub workspace_regex: Option<String>,
     pub content_types: Option<ContentType>,
+    pub is_workspace_container: Option<bool>,
 }
 
 #[derive(Debug, Clone)]

--- a/toml-config/src/config/parsers/window_match.rs
+++ b/toml-config/src/config/parsers/window_match.rs
@@ -93,6 +93,7 @@ impl Parser for WindowMatchParser<'_, '_, '_> {
                 workspace,
                 workspace_regex,
                 content_types_val,
+                is_workspace_container,
             ),
         ) = ext.extract((
             (
@@ -128,6 +129,7 @@ impl Parser for WindowMatchParser<'_, '_, '_> {
                 opt(str("workspace")),
                 opt(str("workspace-regex")),
                 opt(val("content-types")),
+                opt(bol("is-workspace-container")),
             ),
         ))?;
         if let Some(n) = name
@@ -211,6 +213,7 @@ impl Parser for WindowMatchParser<'_, '_, '_> {
             types,
             client,
             content_types,
+            is_workspace_container: is_workspace_container.despan(),
         })
     }
 }

--- a/toml-config/src/rules.rs
+++ b/toml-config/src/rules.rs
@@ -283,6 +283,7 @@ impl Rule for WindowRule {
         bool!(Urgent, urgent);
         bool!(Fullscreen, fullscreen);
         bool!(JustMapped, just_mapped);
+        bool!(IsWorkspaceContainer, is_workspace_container);
         if let Some(value) = match_.focused {
             let crit = WindowCriterion::Focus(state.persistent.seat);
             let matcher = match value {

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -2906,6 +2906,10 @@
         "content-types": {
           "description": "Matches windows whose content type is contained in the mask.",
           "$ref": "#/$defs/ContentTypeMask"
+        },
+        "is-workspace-container": {
+          "type": "boolean",
+          "description": "Matches if the window is/isn't the container of a workspace.\n\nThe workspace container is the outermost container of a workspace. It is\ncreated when the first window is tiled on the workspace and it is the only\ncontainer whose parent is the workspace itself.\n"
         }
       },
       "required": []

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -6362,6 +6362,16 @@ The table has the following fields:
 
   The value of this field should be a [ContentTypeMask](#types-ContentTypeMask).
 
+- `is-workspace-container` (optional):
+
+  Matches if the window is/isn't the container of a workspace.
+  
+  The workspace container is the outermost container of a workspace. It is
+  created when the first window is tiled on the workspace and it is the only
+  container whose parent is the workspace itself.
+
+  The value of this field should be a boolean.
+
 
 <a name="types-WindowMatchExactly"></a>
 ### `WindowMatchExactly`

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -4720,6 +4720,15 @@ WindowMatch:
       ref: ContentTypeMask
       required: false
       description: Matches windows whose content type is contained in the mask.
+    is-workspace-container:
+      kind: boolean
+      required: false
+      description: |
+        Matches if the window is/isn't the container of a workspace.
+
+        The workspace container is the outermost container of a workspace. It is
+        created when the first window is tiled on the workspace and it is the only
+        container whose parent is the workspace itself.
 
 
 WindowMatchExactly:

--- a/toml-spec/spec/window-match.generated.json
+++ b/toml-spec/spec/window-match.generated.json
@@ -272,6 +272,10 @@
         "content-types": {
           "description": "Matches windows whose content type is contained in the mask.",
           "$ref": "#/$defs/ContentTypeMask"
+        },
+        "is-workspace-container": {
+          "type": "boolean",
+          "description": "Matches if the window is/isn't the container of a workspace.\n\nThe workspace container is the outermost container of a workspace. It is\ncreated when the first window is tiled on the workspace and it is the only\ncontainer whose parent is the workspace itself.\n"
         }
       },
       "required": []

--- a/wire/jay_window_match_builder.txt
+++ b/wire/jay_window_match_builder.txt
@@ -76,3 +76,7 @@ request workspace {
 request content_types {
     v: pod(u64),
 }
+
+request is_workspace_container (since = 43) {
+
+}


### PR DESCRIPTION
Allows to match the root container of a workspace in window rules, as discussed in https://github.com/mahkoh/jay/pull/1176.