### PR TITLE
config: add target parameter to container actions & split-major / ... / tile-minor actions

### DIFF
--- a/book/src/configuration/shortcuts.md
+++ b/book/src/configuration/shortcuts.md
@@ -285,6 +285,21 @@ alt-0     = { type = "set-counter", name = "my-counter", value = 0 }
 See [Counters & Triggers](../counters-and-triggers.md) for how to react to the
 resulting values.
 
+### Container actions
+
+The container actions -- `toggle-split`, `tile-horizontal`, `tile-vertical`,
+`toggle-mono`, `show-single`, and `show-all` -- apply to the parent container
+of the window.
+
+In table form, `target` selects a different container: `parent` (the default),
+`self` (the window itself, which must be a container), or `auto` (the window
+itself if it is a container, otherwise its parent).
+
+```toml
+[shortcuts]
+alt-t = { type = "toggle-split", target = "auto" }
+```
+
 ### Other parameterized actions
 
 - `set-keymap` -- change the active keymap
@@ -639,11 +654,13 @@ When certain simple actions are used inside a [window rule](../window-rules.md),
 they apply to the **matched window** instead of the focused window. The
 affected actions are: `move-left`, `move-down`, `move-up`, `move-right`,
 `split-horizontal`, `split-vertical`, `toggle-split`, `tile-horizontal`,
-`tile-vertical`, `show-single`, `show-all`, `toggle-fullscreen`,
+`tile-vertical`, `toggle-mono`, `show-single`, `show-all`, `toggle-fullscreen`,
 `enter-fullscreen`, `exit-fullscreen`, `close`, `toggle-floating`, `float`,
 `tile`, `toggle-float-pinned`, `pin-float`, and `unpin-float`.
 
-The parameterized `resize` action also applies to the matched window.
+The parameterized `resize` action also applies to the matched window. For a
+rule that matches a container, give the
+[container actions](#container-actions) `target = "self"`.
 
 Similarly, `kill-client` applies to the matched window's client in a window
 rule, or to the matched client in a client rule.

--- a/book/src/configuration/shortcuts.md
+++ b/book/src/configuration/shortcuts.md
@@ -288,8 +288,8 @@ resulting values.
 ### Container actions
 
 The container actions -- `toggle-split`, `tile-horizontal`, `tile-vertical`,
-`toggle-mono`, `show-single`, and `show-all` -- apply to the parent container
-of the window.
+`tile-major`, `tile-minor`, `toggle-mono`, `show-single`, and `show-all` --
+apply to the parent container of the window.
 
 In table form, `target` selects a different container: `parent` (the default),
 `self` (the window itself, which must be a container), or `auto` (the window
@@ -653,8 +653,9 @@ mode = {
 When certain simple actions are used inside a [window rule](../window-rules.md),
 they apply to the **matched window** instead of the focused window. The
 affected actions are: `move-left`, `move-down`, `move-up`, `move-right`,
-`split-horizontal`, `split-vertical`, `toggle-split`, `tile-horizontal`,
-`tile-vertical`, `toggle-mono`, `show-single`, `show-all`, `toggle-fullscreen`,
+`split-horizontal`, `split-vertical`, `split-major`, `split-minor`,
+`toggle-split`, `tile-horizontal`, `tile-vertical`, `tile-major`,
+`tile-minor`, `toggle-mono`, `show-single`, `show-all`, `toggle-fullscreen`,
 `enter-fullscreen`, `exit-fullscreen`, `close`, `toggle-floating`, `float`,
 `tile`, `toggle-float-pinned`, `pin-float`, and `unpin-float`.
 

--- a/book/src/tiling.md
+++ b/book/src/tiling.md
@@ -31,6 +31,19 @@ The `tile-horizontal` action sets the container to horizontal, and
 `tile-vertical` sets it to vertical -- unlike `split-horizontal`/`split-vertical`
 which wrap the window in a new container first.
 
+`split-major` and `split-minor` derive the direction from the shape of the
+window instead: `split-major` splits along its longer side, `split-minor`
+along its shorter side. `tile-major` and `tile-minor` do the same for the
+container's shape. A square window counts as wide.
+
+```toml
+[shortcuts]
+alt-Return = ["split-major", { type = "exec", exec = "alacritty" }]
+```
+
+New terminals then appear next to a wide window and below a tall one, keeping
+tiles roughly square.
+
 If the window being split is the only window in its container, the
 [`split-reuses-container`](configuration/misc.md#split-reuses-container)
 option makes the split change that container's direction instead of wrapping the
@@ -159,6 +172,9 @@ Double-click a tile's title bar to toggle it between tiled and floating. See
   [`split-reuses-container`](configuration/misc.md#split-reuses-container),
   make its container vertical if it is the only window in it)
 
+`split-major` / `split-minor`
+: Wrap focused window in a container split along its longer / shorter side
+
 `toggle-split`
 : Toggle container split direction
 
@@ -167,6 +183,9 @@ Double-click a tile's title bar to toggle it between tiled and floating. See
 
 `tile-vertical`
 : Set container direction to vertical
+
+`tile-major` / `tile-minor`
+: Set container direction along its longer / shorter side
 
 `focus-left/right/up/down`
 : Move keyboard focus

--- a/book/src/tiling.md
+++ b/book/src/tiling.md
@@ -102,6 +102,13 @@ alt-s = "show-single"   # Enter mono mode
 alt-a = "show-all"      # Exit mono mode
 ```
 
+## Target Container
+
+The [container actions](configuration/shortcuts.md#container-actions) change
+the parent container of the window they apply to. Their table form takes a
+`target` field to change that -- `"self"` for the window itself when it is a
+container, `"auto"` for whichever of the two is a container.
+
 ## Fullscreen
 
 Press `alt-u` (`toggle-fullscreen`) to make the focused window fill the entire

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -21,6 +21,7 @@ use crate::_private::ipc::ServerMessage;
 use crate::_private::ipc::WorkspaceSource;
 use crate::_private::logging;
 use crate::Axis;
+use crate::ContainerTarget;
 use crate::Direction;
 use crate::ModifiedKeySym;
 use crate::PciId;
@@ -928,6 +929,56 @@ impl ConfigClient {
 
     pub fn create_window_split(&self, window: Window, axis: Axis) {
         self.send(&ClientMessage::CreateWindowSplit { window, axis });
+    }
+
+    pub fn seat_container_mono(&self, seat: Seat, target: ContainerTarget) -> bool {
+        let res = self.send_with_response(&ClientMessage::GetSeatContainerMono { seat, target });
+        get_response!(res, false, GetMono { mono });
+        mono
+    }
+
+    pub fn set_seat_container_mono(&self, seat: Seat, target: ContainerTarget, mono: bool) {
+        self.send(&ClientMessage::SetSeatContainerMono { seat, target, mono });
+    }
+
+    pub fn seat_container_split(&self, seat: Seat, target: ContainerTarget) -> Axis {
+        let res = self.send_with_response(&ClientMessage::GetSeatContainerSplit { seat, target });
+        get_response!(res, Axis::Horizontal, GetSplit { axis });
+        axis
+    }
+
+    pub fn set_seat_container_split(&self, seat: Seat, target: ContainerTarget, axis: Axis) {
+        self.send(&ClientMessage::SetSeatContainerSplit { seat, target, axis });
+    }
+
+    pub fn window_container_mono(&self, window: Window, target: ContainerTarget) -> bool {
+        let res =
+            self.send_with_response(&ClientMessage::GetWindowContainerMono { window, target });
+        get_response!(res, false, GetWindowMono { mono });
+        mono
+    }
+
+    pub fn set_window_container_mono(&self, window: Window, target: ContainerTarget, mono: bool) {
+        self.send(&ClientMessage::SetWindowContainerMono {
+            window,
+            target,
+            mono,
+        });
+    }
+
+    pub fn window_container_split(&self, window: Window, target: ContainerTarget) -> Axis {
+        let res =
+            self.send_with_response(&ClientMessage::GetWindowContainerSplit { window, target });
+        get_response!(res, Axis::Horizontal, GetWindowSplit { axis });
+        axis
+    }
+
+    pub fn set_window_container_split(&self, window: Window, target: ContainerTarget, axis: Axis) {
+        self.send(&ClientMessage::SetWindowContainerSplit {
+            window,
+            target,
+            axis,
+        });
     }
 
     pub fn seat_close(&self, seat: Seat) {

--- a/jay-config/src/_private/client.rs
+++ b/jay-config/src/_private/client.rs
@@ -25,6 +25,7 @@ use crate::ContainerTarget;
 use crate::Direction;
 use crate::ModifiedKeySym;
 use crate::PciId;
+use crate::RelativeAxis;
 use crate::Workspace;
 use crate::WorkspaceKind;
 use crate::WorkspaceShowOp;
@@ -975,6 +976,36 @@ impl ConfigClient {
 
     pub fn set_window_container_split(&self, window: Window, target: ContainerTarget, axis: Axis) {
         self.send(&ClientMessage::SetWindowContainerSplit {
+            window,
+            target,
+            axis,
+        });
+    }
+
+    pub fn create_seat_split_relative(&self, seat: Seat, axis: RelativeAxis) {
+        self.send(&ClientMessage::CreateSeatSplitRelative { seat, axis });
+    }
+
+    pub fn create_window_split_relative(&self, window: Window, axis: RelativeAxis) {
+        self.send(&ClientMessage::CreateWindowSplitRelative { window, axis });
+    }
+
+    pub fn set_seat_container_split_relative(
+        &self,
+        seat: Seat,
+        target: ContainerTarget,
+        axis: RelativeAxis,
+    ) {
+        self.send(&ClientMessage::SetSeatContainerSplitRelative { seat, target, axis });
+    }
+
+    pub fn set_window_container_split_relative(
+        &self,
+        window: Window,
+        target: ContainerTarget,
+        axis: RelativeAxis,
+    ) {
+        self.send(&ClientMessage::SetWindowContainerSplitRelative {
             window,
             target,
             axis,

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -9,6 +9,7 @@ use crate::Axis;
 use crate::ContainerTarget;
 use crate::Direction;
 use crate::PciId;
+use crate::RelativeAxis;
 use crate::Workspace;
 use crate::WorkspaceKind;
 use crate::client::Client;
@@ -1064,6 +1065,24 @@ pub enum ClientMessage<'a> {
         window: Window,
         target: ContainerTarget,
         axis: Axis,
+    },
+    CreateSeatSplitRelative {
+        seat: Seat,
+        axis: RelativeAxis,
+    },
+    CreateWindowSplitRelative {
+        window: Window,
+        axis: RelativeAxis,
+    },
+    SetSeatContainerSplitRelative {
+        seat: Seat,
+        target: ContainerTarget,
+        axis: RelativeAxis,
+    },
+    SetWindowContainerSplitRelative {
+        window: Window,
+        target: ContainerTarget,
+        axis: RelativeAxis,
     },
 }
 

--- a/jay-config/src/_private/ipc.rs
+++ b/jay-config/src/_private/ipc.rs
@@ -6,6 +6,7 @@ use crate::_private::WireMode;
 use crate::_private::WorkspaceShowOpV1;
 use crate::_private::WorkspaceShowOpV2;
 use crate::Axis;
+use crate::ContainerTarget;
 use crate::Direction;
 use crate::PciId;
 use crate::Workspace;
@@ -1027,6 +1028,42 @@ pub enum ClientMessage<'a> {
         matcher: WindowMatcher,
         x: i32,
         y: i32,
+    },
+    GetSeatContainerMono {
+        seat: Seat,
+        target: ContainerTarget,
+    },
+    SetSeatContainerMono {
+        seat: Seat,
+        target: ContainerTarget,
+        mono: bool,
+    },
+    GetSeatContainerSplit {
+        seat: Seat,
+        target: ContainerTarget,
+    },
+    SetSeatContainerSplit {
+        seat: Seat,
+        target: ContainerTarget,
+        axis: Axis,
+    },
+    GetWindowContainerMono {
+        window: Window,
+        target: ContainerTarget,
+    },
+    SetWindowContainerMono {
+        window: Window,
+        target: ContainerTarget,
+        mono: bool,
+    },
+    GetWindowContainerSplit {
+        window: Window,
+        target: ContainerTarget,
+    },
+    SetWindowContainerSplit {
+        window: Window,
+        target: ContainerTarget,
+        axis: Axis,
     },
 }
 

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -9,6 +9,7 @@ pub mod scrollmethod;
 use crate::_private::DEFAULT_SEAT_NAME;
 use crate::_private::ipc::WorkspaceSource;
 use crate::Axis;
+use crate::ContainerTarget;
 use crate::Direction;
 use crate::ModifiedKeySym;
 use crate::Workspace;
@@ -433,6 +434,38 @@ impl Seat {
     /// Toggles the split axis of the parent-container of the currently focused window.
     pub fn toggle_split(self) {
         self.set_split(self.split().other());
+    }
+
+    /// Returns whether the target container of the currently focused window is in
+    /// mono-mode.
+    pub fn container_mono(self, target: ContainerTarget) -> bool {
+        get!(false).seat_container_mono(self, target)
+    }
+
+    /// Sets whether the target container of the currently focused window is in mono-mode.
+    pub fn set_container_mono(self, target: ContainerTarget, mono: bool) {
+        get!().set_seat_container_mono(self, target, mono)
+    }
+
+    /// Toggles whether the target container of the currently focused window is in
+    /// mono-mode.
+    pub fn toggle_container_mono(self, target: ContainerTarget) {
+        self.set_container_mono(target, !self.container_mono(target));
+    }
+
+    /// Returns the split axis of the target container of the currently focused window.
+    pub fn container_split(self, target: ContainerTarget) -> Axis {
+        get!(Axis::Horizontal).seat_container_split(self, target)
+    }
+
+    /// Sets the split axis of the target container of the currently focused window.
+    pub fn set_container_split(self, target: ContainerTarget, axis: Axis) {
+        get!().set_seat_container_split(self, target, axis)
+    }
+
+    /// Toggles the split axis of the target container of the currently focused window.
+    pub fn toggle_container_split(self, target: ContainerTarget) {
+        self.set_container_split(target, self.container_split(target).other());
     }
 
     /// Returns the input devices assigned to this seat.

--- a/jay-config/src/input.rs
+++ b/jay-config/src/input.rs
@@ -12,6 +12,7 @@ use crate::Axis;
 use crate::ContainerTarget;
 use crate::Direction;
 use crate::ModifiedKeySym;
+use crate::RelativeAxis;
 use crate::Workspace;
 use crate::input::acceleration::AccelProfile;
 use crate::input::capability::Capability;
@@ -468,6 +469,12 @@ impl Seat {
         self.set_container_split(target, self.container_split(target).other());
     }
 
+    /// Sets the split axis of the target container of the currently focused window
+    /// relative to the dimensions of that container.
+    pub fn set_container_split_relative(self, target: ContainerTarget, axis: RelativeAxis) {
+        get!().set_seat_container_split_relative(self, target, axis)
+    }
+
     /// Returns the input devices assigned to this seat.
     pub fn input_devices(self) -> Vec<InputDevice> {
         get!().get_input_devices(Some(self))
@@ -480,6 +487,16 @@ impl Seat {
     /// split axis of that container is changed instead.
     pub fn create_split(self, axis: Axis) {
         get!().create_seat_split(self, axis);
+    }
+
+    /// Creates a new container in place of the currently focused window with a split
+    /// relative to the dimensions of that window.
+    ///
+    /// If the window is the only child of its container and
+    /// [`set_split_reuses_container`](crate::set_split_reuses_container) is enabled, the
+    /// split axis of that container is changed instead.
+    pub fn create_split_relative(self, axis: RelativeAxis) {
+        get!().create_seat_split_relative(self, axis);
     }
 
     /// Focuses the parent node of the currently focused window.

--- a/jay-config/src/lib.rs
+++ b/jay-config/src/lib.rs
@@ -104,6 +104,21 @@ impl Axis {
     }
 }
 
+/// The container that an action operates on.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq, Default)]
+#[non_exhaustive]
+pub enum ContainerTarget {
+    /// The parent container of the window. This is the default.
+    #[default]
+    Parent,
+    /// The window itself.
+    ///
+    /// The action has no effect if the window is not a container.
+    Itself,
+    /// The window itself if it is a container, otherwise its parent container.
+    Auto,
+}
+
 /// Exits the compositor.
 pub fn quit() {
     get!().quit()

--- a/jay-config/src/lib.rs
+++ b/jay-config/src/lib.rs
@@ -104,6 +104,19 @@ impl Axis {
     }
 }
 
+/// A planar axis relative to the dimensions of a node.
+///
+/// If the node is exactly as wide as it is high, `Major` is `Axis::Horizontal` and
+/// `Minor` is `Axis::Vertical`.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum RelativeAxis {
+    /// The axis along the larger dimension of the node.
+    Major,
+    /// The axis along the smaller dimension of the node.
+    Minor,
+}
+
 /// The container that an action operates on.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, Eq, PartialEq, Default)]
 #[non_exhaustive]

--- a/jay-config/src/window.rs
+++ b/jay-config/src/window.rs
@@ -3,6 +3,7 @@
 use crate::Axis;
 use crate::ContainerTarget;
 use crate::Direction;
+use crate::RelativeAxis;
 use crate::Workspace;
 use crate::client::Client;
 use crate::client::ClientCriterion;
@@ -198,6 +199,12 @@ impl Window {
         self.set_container_split(target, self.container_split(target).other());
     }
 
+    /// Sets the split axis of the target container of the window relative to the
+    /// dimensions of that container.
+    pub fn set_container_split_relative(self, target: ContainerTarget, axis: RelativeAxis) {
+        get!().set_window_container_split_relative(self, target, axis)
+    }
+
     /// Creates a new container with the specified split in place of the window.
     ///
     /// If the window is the only child of its container and
@@ -205,6 +212,16 @@ impl Window {
     /// split axis of that container is changed instead.
     pub fn create_split(self, axis: Axis) {
         get!().create_window_split(self, axis);
+    }
+
+    /// Creates a new container in place of the window with a split relative to the
+    /// dimensions of that window.
+    ///
+    /// If the window is the only child of its container and
+    /// [`set_split_reuses_container`](crate::set_split_reuses_container) is enabled, the
+    /// split axis of that container is changed instead.
+    pub fn create_split_relative(self, axis: RelativeAxis) {
+        get!().create_window_split_relative(self, axis);
     }
 
     /// Requests the window to be closed.

--- a/jay-config/src/window.rs
+++ b/jay-config/src/window.rs
@@ -1,6 +1,7 @@
 //! Tools for inspecting and manipulating windows.
 
 use crate::Axis;
+use crate::ContainerTarget;
 use crate::Direction;
 use crate::Workspace;
 use crate::client::Client;
@@ -165,6 +166,36 @@ impl Window {
     /// Toggles the split axis of the parent-container of the window.
     pub fn toggle_split(self) {
         self.set_split(self.split().other());
+    }
+
+    /// Returns whether the target container of the window is in mono-mode.
+    pub fn container_mono(self, target: ContainerTarget) -> bool {
+        get!(false).window_container_mono(self, target)
+    }
+
+    /// Sets whether the target container of the window is in mono-mode.
+    pub fn set_container_mono(self, target: ContainerTarget, mono: bool) {
+        get!().set_window_container_mono(self, target, mono)
+    }
+
+    /// Toggles whether the target container of the window is in mono-mode.
+    pub fn toggle_container_mono(self, target: ContainerTarget) {
+        self.set_container_mono(target, !self.container_mono(target));
+    }
+
+    /// Returns the split axis of the target container of the window.
+    pub fn container_split(self, target: ContainerTarget) -> Axis {
+        get!(Axis::Horizontal).window_container_split(self, target)
+    }
+
+    /// Sets the split axis of the target container of the window.
+    pub fn set_container_split(self, target: ContainerTarget, axis: Axis) {
+        get!().set_window_container_split(self, target, axis)
+    }
+
+    /// Toggles the split axis of the target container of the window.
+    pub fn toggle_container_split(self, target: ContainerTarget) {
+        self.set_container_split(target, self.container_split(target).other());
     }
 
     /// Creates a new container with the specified split in place of the window.

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -51,6 +51,7 @@ use crate::tree::ContainerTarget;
 use crate::tree::NodeBase;
 use crate::tree::OutputNode;
 use crate::tree::OutputNodeOrPersistent;
+use crate::tree::RelativeAxis;
 use crate::tree::TearingMode;
 use crate::tree::TileState;
 use crate::tree::ToplevelData;
@@ -98,6 +99,7 @@ use jay_config::_private::serialize_server_message;
 use jay_config::Axis;
 use jay_config::ContainerTarget as ConfigContainerTarget;
 use jay_config::Direction;
+use jay_config::RelativeAxis as ConfigRelativeAxis;
 use jay_config::Workspace;
 use jay_config::WorkspaceKind;
 use jay_config::client::Client as ConfigClient;
@@ -2225,6 +2227,59 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
+    fn handle_create_seat_split_relative(
+        &self,
+        seat: Seat,
+        axis: ConfigRelativeAxis,
+    ) -> Result<(), CphError> {
+        let axis = map_relative_axis(axis)?;
+        let seat = self.get_seat(seat)?;
+        seat.create_split_relative(axis);
+        Ok(())
+    }
+
+    fn handle_create_window_split_relative(
+        &self,
+        window: Window,
+        axis: ConfigRelativeAxis,
+    ) -> Result<(), CphError> {
+        let axis = map_relative_axis(axis)?;
+        let window = self.get_window(window)?;
+        let pos = window.node_absolute_position(LiveTL);
+        let split = ContainerSplit::from_relative_axis(axis, &pos);
+        toplevel_create_split(&self.state, window, split);
+        Ok(())
+    }
+
+    fn handle_set_seat_split_relative(
+        &self,
+        seat: Seat,
+        target: ConfigContainerTarget,
+        axis: ConfigRelativeAxis,
+    ) -> Result<(), CphError> {
+        let target = map_container_target(target)?;
+        let axis = map_relative_axis(axis)?;
+        let seat = self.get_seat(seat)?;
+        seat.set_split_relative(target, axis);
+        Ok(())
+    }
+
+    fn handle_set_window_split_relative(
+        &self,
+        window: Window,
+        target: ConfigContainerTarget,
+        axis: ConfigRelativeAxis,
+    ) -> Result<(), CphError> {
+        let target = map_container_target(target)?;
+        let axis = map_relative_axis(axis)?;
+        let window = self.get_window(window)?;
+        if let Some(c) = toplevel_target_container(&window, target) {
+            let pos = c.node_absolute_position(LiveTL);
+            c.set_split(ContainerSplit::from_relative_axis(axis, &pos));
+        }
+        Ok(())
+    }
+
     fn handle_add_shortcut(
         &self,
         seat: Seat,
@@ -4221,6 +4276,22 @@ impl ConfigProxyHandler {
             } => self
                 .handle_set_window_split(window, Some(target), axis)
                 .wrn("set_window_container_split")?,
+            ClientMessage::CreateSeatSplitRelative { seat, axis } => self
+                .handle_create_seat_split_relative(seat, axis)
+                .wrn("create_seat_split_relative")?,
+            ClientMessage::CreateWindowSplitRelative { window, axis } => self
+                .handle_create_window_split_relative(window, axis)
+                .wrn("create_window_split_relative")?,
+            ClientMessage::SetSeatContainerSplitRelative { seat, target, axis } => self
+                .handle_set_seat_split_relative(seat, target, axis)
+                .wrn("set_seat_container_split_relative")?,
+            ClientMessage::SetWindowContainerSplitRelative {
+                window,
+                target,
+                axis,
+            } => self
+                .handle_set_window_split_relative(window, target, axis)
+                .wrn("set_window_container_split_relative")?,
         }
         Ok(())
     }
@@ -4412,6 +4483,8 @@ enum CphError {
     UnknownScalingFilter(ConfigScalingFilter),
     #[error("Tried to use an unknown container target: {0:?}")]
     UnknownContainerTarget(ConfigContainerTarget),
+    #[error("Tried to use an unknown relative axis: {0:?}")]
+    UnknownRelativeAxis(ConfigRelativeAxis),
 }
 
 trait WithRequestName {
@@ -4456,6 +4529,15 @@ fn map_container_target(target: ConfigContainerTarget) -> Result<ContainerTarget
         ConfigContainerTarget::Itself => ContainerTarget::Itself,
         ConfigContainerTarget::Auto => ContainerTarget::Auto,
         _ => return Err(CphError::UnknownContainerTarget(target)),
+    };
+    Ok(res)
+}
+
+fn map_relative_axis(axis: ConfigRelativeAxis) -> Result<RelativeAxis, CphError> {
+    let res = match axis {
+        ConfigRelativeAxis::Major => RelativeAxis::Major,
+        ConfigRelativeAxis::Minor => RelativeAxis::Minor,
+        _ => return Err(CphError::UnknownRelativeAxis(axis)),
     };
     Ok(res)
 }

--- a/src/config/handler.rs
+++ b/src/config/handler.rs
@@ -47,6 +47,7 @@ use crate::tagged_acceptor::TaggedAcceptorError;
 use crate::theme::ThemeColored;
 use crate::theme::ThemeSized;
 use crate::tree::ContainerSplit;
+use crate::tree::ContainerTarget;
 use crate::tree::NodeBase;
 use crate::tree::OutputNode;
 use crate::tree::OutputNodeOrPersistent;
@@ -64,7 +65,9 @@ use crate::tree::move_ws_to_output;
 use crate::tree::toplevel_create_split;
 use crate::tree::toplevel_parent_container;
 use crate::tree::toplevel_set_floating;
+use crate::tree::toplevel_set_target_mono;
 use crate::tree::toplevel_set_workspace;
+use crate::tree::toplevel_target_container;
 use crate::utils::asyncevent::AsyncEvent;
 use crate::utils::copyhashmap::CopyHashMap;
 use crate::utils::errorfmt::ErrorFmt;
@@ -93,6 +96,7 @@ use jay_config::_private::ipc::ServerMessage;
 use jay_config::_private::ipc::WorkspaceSource;
 use jay_config::_private::serialize_server_message;
 use jay_config::Axis;
+use jay_config::ContainerTarget as ConfigContainerTarget;
 use jay_config::Direction;
 use jay_config::Workspace;
 use jay_config::WorkspaceKind;
@@ -2111,59 +2115,95 @@ impl ConfigProxyHandler {
         }
     }
 
-    fn handle_get_seat_mono(&self, seat: Seat) -> Result<(), CphError> {
+    fn handle_get_seat_mono(
+        &self,
+        seat: Seat,
+        target: Option<ConfigContainerTarget>,
+    ) -> Result<(), CphError> {
+        let target = map_container_target_opt(target)?;
         let seat = self.get_seat(seat)?;
         self.respond(Response::GetMono {
-            mono: seat.get_mono().unwrap_or(false),
+            mono: seat.get_mono(target).unwrap_or(false),
         });
         Ok(())
     }
 
-    fn handle_set_seat_mono(&self, seat: Seat, mono: bool) -> Result<(), CphError> {
+    fn handle_set_seat_mono(
+        &self,
+        seat: Seat,
+        target: Option<ConfigContainerTarget>,
+        mono: bool,
+    ) -> Result<(), CphError> {
+        let target = map_container_target_opt(target)?;
         let seat = self.get_seat(seat)?;
-        seat.set_mono(mono);
+        seat.set_mono(target, mono);
         Ok(())
     }
 
-    fn handle_get_window_mono(&self, window: Window) -> Result<(), CphError> {
+    fn handle_get_window_mono(
+        &self,
+        window: Window,
+        target: Option<ConfigContainerTarget>,
+    ) -> Result<(), CphError> {
+        let target = map_container_target_opt(target)?;
         let window = self.get_window(window)?;
         self.respond(Response::GetWindowMono {
-            mono: toplevel_parent_container(&*window)
+            mono: toplevel_target_container(&window, target)
                 .map(|c| c.node_state[LiveTL].mono_child.is_some())
                 .unwrap_or(false),
         });
         Ok(())
     }
 
-    fn handle_set_window_mono(&self, window: Window, mono: bool) -> Result<(), CphError> {
+    fn handle_set_window_mono(
+        &self,
+        window: Window,
+        target: Option<ConfigContainerTarget>,
+        mono: bool,
+    ) -> Result<(), CphError> {
+        let target = map_container_target_opt(target)?;
         let window = self.get_window(window)?;
-        if let Some(c) = toplevel_parent_container(&*window) {
-            c.set_mono(mono.then_some(window.as_ref()));
-        }
+        toplevel_set_target_mono(&window, target, mono);
         Ok(())
     }
 
-    fn handle_get_seat_split(&self, seat: Seat) -> Result<(), CphError> {
+    fn handle_get_seat_split(
+        &self,
+        seat: Seat,
+        target: Option<ConfigContainerTarget>,
+    ) -> Result<(), CphError> {
+        let target = map_container_target_opt(target)?;
         let seat = self.get_seat(seat)?;
         self.respond(Response::GetSplit {
             axis: seat
-                .get_split()
+                .get_split(target)
                 .unwrap_or(ContainerSplit::Horizontal)
                 .into(),
         });
         Ok(())
     }
 
-    fn handle_set_seat_split(&self, seat: Seat, axis: Axis) -> Result<(), CphError> {
+    fn handle_set_seat_split(
+        &self,
+        seat: Seat,
+        target: Option<ConfigContainerTarget>,
+        axis: Axis,
+    ) -> Result<(), CphError> {
+        let target = map_container_target_opt(target)?;
         let seat = self.get_seat(seat)?;
-        seat.set_split(axis.into());
+        seat.set_split(target, axis.into());
         Ok(())
     }
 
-    fn handle_get_window_split(&self, window: Window) -> Result<(), CphError> {
+    fn handle_get_window_split(
+        &self,
+        window: Window,
+        target: Option<ConfigContainerTarget>,
+    ) -> Result<(), CphError> {
+        let target = map_container_target_opt(target)?;
         let window = self.get_window(window)?;
         self.respond(Response::GetWindowSplit {
-            axis: toplevel_parent_container(&*window)
+            axis: toplevel_target_container(&window, target)
                 .map(|c| c.node_state[LiveTL].split.get())
                 .unwrap_or(ContainerSplit::Horizontal)
                 .into(),
@@ -2171,9 +2211,15 @@ impl ConfigProxyHandler {
         Ok(())
     }
 
-    fn handle_set_window_split(&self, window: Window, axis: Axis) -> Result<(), CphError> {
+    fn handle_set_window_split(
+        &self,
+        window: Window,
+        target: Option<ConfigContainerTarget>,
+        axis: Axis,
+    ) -> Result<(), CphError> {
+        let target = map_container_target_opt(target)?;
         let window = self.get_window(window)?;
-        if let Some(c) = toplevel_parent_container(&*window) {
+        if let Some(c) = toplevel_target_container(&window, target) {
             c.set_split(axis.into());
         }
         Ok(())
@@ -3398,16 +3444,16 @@ impl ConfigProxyHandler {
                 self.handle_set_seat(device, seat).wrn("set_seat")?
             }
             ClientMessage::GetSeatMono { seat } => {
-                self.handle_get_seat_mono(seat).wrn("get_seat_mono")?
+                self.handle_get_seat_mono(seat, None).wrn("get_seat_mono")?
             }
-            ClientMessage::SetSeatMono { seat, mono } => {
-                self.handle_set_seat_mono(seat, mono).wrn("set_seat_mono")?
-            }
-            ClientMessage::GetSeatSplit { seat } => {
-                self.handle_get_seat_split(seat).wrn("get_seat_split")?
-            }
+            ClientMessage::SetSeatMono { seat, mono } => self
+                .handle_set_seat_mono(seat, None, mono)
+                .wrn("set_seat_mono")?,
+            ClientMessage::GetSeatSplit { seat } => self
+                .handle_get_seat_split(seat, None)
+                .wrn("get_seat_split")?,
             ClientMessage::SetSeatSplit { seat, axis } => self
-                .handle_set_seat_split(seat, axis)
+                .handle_set_seat_split(seat, None, axis)
                 .wrn("set_seat_split")?,
             ClientMessage::AddShortcut { seat, mods, sym } => self
                 .handle_add_shortcut(seat, Modifiers(!0), mods, sym)
@@ -3823,16 +3869,16 @@ impl ConfigProxyHandler {
                 .handle_get_window_children(window)
                 .wrn("get_window_children")?,
             ClientMessage::GetWindowSplit { window } => self
-                .handle_get_window_split(window)
+                .handle_get_window_split(window, None)
                 .wrn("get_window_split")?,
             ClientMessage::SetWindowSplit { window, axis } => self
-                .handle_set_window_split(window, axis)
+                .handle_set_window_split(window, None, axis)
                 .wrn("set_window_split")?,
-            ClientMessage::GetWindowMono { window } => {
-                self.handle_get_window_mono(window).wrn("get_window_mono")?
-            }
+            ClientMessage::GetWindowMono { window } => self
+                .handle_get_window_mono(window, None)
+                .wrn("get_window_mono")?,
             ClientMessage::SetWindowMono { window, mono } => self
-                .handle_set_window_mono(window, mono)
+                .handle_set_window_mono(window, None, mono)
                 .wrn("set_window_mono")?,
             ClientMessage::WindowMove { window, direction } => self
                 .handle_window_move(window, direction)
@@ -4143,6 +4189,38 @@ impl ConfigProxyHandler {
             ClientMessage::GetPlaneColorPipelinesEnabled { device } => self
                 .handle_get_plane_color_pipelines_enabled(device)
                 .wrn("get_plane_color_pipelines_enabled")?,
+            ClientMessage::GetSeatContainerMono { seat, target } => self
+                .handle_get_seat_mono(seat, Some(target))
+                .wrn("get_seat_container_mono")?,
+            ClientMessage::SetSeatContainerMono { seat, target, mono } => self
+                .handle_set_seat_mono(seat, Some(target), mono)
+                .wrn("set_seat_container_mono")?,
+            ClientMessage::GetSeatContainerSplit { seat, target } => self
+                .handle_get_seat_split(seat, Some(target))
+                .wrn("get_seat_container_split")?,
+            ClientMessage::SetSeatContainerSplit { seat, target, axis } => self
+                .handle_set_seat_split(seat, Some(target), axis)
+                .wrn("set_seat_container_split")?,
+            ClientMessage::GetWindowContainerMono { window, target } => self
+                .handle_get_window_mono(window, Some(target))
+                .wrn("get_window_container_mono")?,
+            ClientMessage::SetWindowContainerMono {
+                window,
+                target,
+                mono,
+            } => self
+                .handle_set_window_mono(window, Some(target), mono)
+                .wrn("set_window_container_mono")?,
+            ClientMessage::GetWindowContainerSplit { window, target } => self
+                .handle_get_window_split(window, Some(target))
+                .wrn("get_window_container_split")?,
+            ClientMessage::SetWindowContainerSplit {
+                window,
+                target,
+                axis,
+            } => self
+                .handle_set_window_split(window, Some(target), axis)
+                .wrn("set_window_container_split")?,
         }
         Ok(())
     }
@@ -4332,6 +4410,8 @@ enum CphError {
     UnknownScrollButton(ConfigInputEventCode),
     #[error("Tried to set an unknown scaling filter: {}", (.0).0)]
     UnknownScalingFilter(ConfigScalingFilter),
+    #[error("Tried to use an unknown container target: {0:?}")]
+    UnknownContainerTarget(ConfigContainerTarget),
 }
 
 trait WithRequestName {
@@ -4359,4 +4439,23 @@ fn map_fallback_output_mode(
 ) -> Result<crate::ifs::wl_seat::FallbackOutputMode, CphError> {
     fom.try_into()
         .map_err(|_| CphError::UnknownFallbackOutputMode(fom))
+}
+
+fn map_container_target_opt(
+    target: Option<ConfigContainerTarget>,
+) -> Result<ContainerTarget, CphError> {
+    let Some(target) = target else {
+        return Ok(ContainerTarget::Parent);
+    };
+    map_container_target(target)
+}
+
+fn map_container_target(target: ConfigContainerTarget) -> Result<ContainerTarget, CphError> {
+    let res = match target {
+        ConfigContainerTarget::Parent => ContainerTarget::Parent,
+        ConfigContainerTarget::Itself => ContainerTarget::Itself,
+        ConfigContainerTarget::Auto => ContainerTarget::Auto,
+        _ => return Err(CphError::UnknownContainerTarget(target)),
+    };
+    Ok(res)
 }

--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -105,6 +105,7 @@ use crate::state::DeviceHandlerData;
 use crate::state::State;
 use crate::tree::ContainerNode;
 use crate::tree::ContainerSplit;
+use crate::tree::ContainerTarget;
 use crate::tree::Direction;
 use crate::tree::FoundNode;
 use crate::tree::Node;
@@ -122,9 +123,10 @@ use crate::tree::WorkspaceNode;
 use crate::tree::generic_node_visitor;
 use crate::tree::toplevel_create_split;
 use crate::tree::toplevel_data_parent_container;
-use crate::tree::toplevel_parent_container;
 use crate::tree::toplevel_set_floating;
+use crate::tree::toplevel_set_target_mono;
 use crate::tree::toplevel_set_workspace;
+use crate::tree::toplevel_target_container;
 use crate::utils::asyncevent::AsyncEvent;
 use crate::utils::bhash::BHashMap;
 use crate::utils::bindings::PerClientBindings;
@@ -775,32 +777,29 @@ impl WlSeatGlobal {
         self.kb_owner.ungrab(self);
     }
 
-    pub fn kb_parent_container(&self) -> Option<Rc<ContainerNode>> {
+    pub fn kb_target_container(&self, target: ContainerTarget) -> Option<Rc<ContainerNode>> {
         let tl = self.keyboard_node.get().node_toplevel()?;
-        toplevel_parent_container(&*tl)
+        toplevel_target_container(&tl, target)
     }
 
-    pub fn get_mono(&self) -> Option<bool> {
-        self.kb_parent_container()
+    pub fn get_mono(&self, target: ContainerTarget) -> Option<bool> {
+        self.kb_target_container(target)
             .map(|c| c.node_state[LiveTL].mono_child.is_some())
     }
 
-    pub fn get_split(&self) -> Option<ContainerSplit> {
-        self.kb_parent_container()
+    pub fn get_split(&self, target: ContainerTarget) -> Option<ContainerSplit> {
+        self.kb_target_container(target)
             .map(|c| c.node_state[LiveTL].split.get())
     }
 
-    pub fn set_mono(&self, mono: bool) {
-        if let Some(tl) = self.keyboard_node.get().node_toplevel()
-            && let Some(container) = toplevel_parent_container(&*tl)
-        {
-            let node = if mono { Some(tl.deref()) } else { None };
-            container.set_mono(node);
+    pub fn set_mono(&self, target: ContainerTarget, mono: bool) {
+        if let Some(tl) = self.keyboard_node.get().node_toplevel() {
+            toplevel_set_target_mono(&tl, target, mono);
         }
     }
 
-    pub fn set_split(&self, axis: ContainerSplit) {
-        if let Some(c) = self.kb_parent_container() {
+    pub fn set_split(&self, target: ContainerTarget, axis: ContainerSplit) {
+        if let Some(c) = self.kb_target_container(target) {
             c.set_split(axis);
         }
     }

--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -115,6 +115,7 @@ use crate::tree::NodeLayerLink;
 use crate::tree::NodeLocation;
 use crate::tree::NodesStack;
 use crate::tree::OutputNode;
+use crate::tree::RelativeAxis;
 use crate::tree::StackedNode;
 use crate::tree::ToplevelNode;
 use crate::tree::TreeTimeline::LiveTL;
@@ -804,12 +805,31 @@ impl WlSeatGlobal {
         }
     }
 
+    pub fn set_split_relative(&self, target: ContainerTarget, axis: RelativeAxis) {
+        if let Some(c) = self.kb_target_container(target) {
+            let pos = c.node_absolute_position(LiveTL);
+            c.set_split(ContainerSplit::from_relative_axis(axis, &pos));
+        }
+    }
+
     pub fn create_split(&self, axis: ContainerSplit) {
         let tl = match self.keyboard_node.get().node_toplevel() {
             Some(tl) => tl,
             _ => return,
         };
         toplevel_create_split(&self.state, tl, axis);
+    }
+
+    pub fn create_split_relative(&self, axis: RelativeAxis) {
+        let Some(tl) = self.keyboard_node.get().node_toplevel() else {
+            return;
+        };
+        let pos = tl.node_absolute_position(LiveTL);
+        toplevel_create_split(
+            &self.state,
+            tl,
+            ContainerSplit::from_relative_axis(axis, &pos),
+        );
     }
 
     pub fn focus_parent(self: &Rc<Self>) {

--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -775,10 +775,8 @@ impl WlSeatGlobal {
     }
 
     pub fn kb_parent_container(&self) -> Option<Rc<ContainerNode>> {
-        if let Some(tl) = self.keyboard_node.get().node_toplevel() {
-            return toplevel_parent_container(&*tl);
-        }
-        None
+        let tl = self.keyboard_node.get().node_toplevel()?;
+        toplevel_parent_container(&*tl)
     }
 
     pub fn get_mono(&self) -> Option<bool> {

--- a/src/ifs/wl_seat.rs
+++ b/src/ifs/wl_seat.rs
@@ -121,6 +121,7 @@ use crate::tree::WorkspaceChangeReason;
 use crate::tree::WorkspaceNode;
 use crate::tree::generic_node_visitor;
 use crate::tree::toplevel_create_split;
+use crate::tree::toplevel_data_parent_container;
 use crate::tree::toplevel_parent_container;
 use crate::tree::toplevel_set_floating;
 use crate::tree::toplevel_set_workspace;
@@ -791,8 +792,7 @@ impl WlSeatGlobal {
 
     pub fn set_mono(&self, mono: bool) {
         if let Some(tl) = self.keyboard_node.get().node_toplevel()
-            && let Some(parent) = tl.tl_data().parent.get()
-            && let Some(container) = parent.node_into_container()
+            && let Some(container) = toplevel_parent_container(&*tl)
         {
             let node = if mono { Some(tl.deref()) } else { None };
             container.set_mono(node);
@@ -893,9 +893,7 @@ impl WlSeatGlobal {
                 && let Some(target) = self.state.find_output_in_direction(&output, direction)
             {
                 target.take_keyboard_navigation_focus(self, direction);
-            } else if let Some(p) = data.parent.get()
-                && let Some(c) = p.node_into_container()
-            {
+            } else if let Some(c) = toplevel_data_parent_container(data) {
                 c.move_focus_from_child(self, tl.deref(), direction);
             }
         }
@@ -934,9 +932,7 @@ impl WlSeatGlobal {
             let ws = target.ensure_workspace();
             toplevel_set_workspace(&self.state, tl, &ws);
             self.maybe_schedule_warp_mouse_to_focus();
-        } else if let Some(parent) = data.parent.get()
-            && let Some(c) = parent.node_into_container()
-        {
+        } else if let Some(c) = toplevel_data_parent_container(data) {
             c.move_child(tl, direction);
             self.maybe_schedule_warp_mouse_to_focus();
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1060,3 +1060,9 @@ pub enum ContainerTarget {
     Itself,
     Auto,
 }
+
+#[derive(Copy, Clone)]
+pub enum RelativeAxis {
+    Major,
+    Minor,
+}

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1053,3 +1053,10 @@ impl<T> LinkedList<TreeLink<T>> {
         self.rev_iter_valid(tl).next()
     }
 }
+
+#[derive(Copy, Clone)]
+pub enum ContainerTarget {
+    Parent,
+    Itself,
+    Auto,
+}

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -1525,6 +1525,13 @@ impl ContainerNode {
         }
     }
 
+    fn last_focus_or_last(&self) -> Option<NodeRef<ContainerChild>> {
+        match self.focus_history.last() {
+            Some(l) => Some(l.deref().clone()),
+            None => self.children.last_valid(LiveTL),
+        }
+    }
+
     fn button(
         self: Rc<Self>,
         id: CursorType,
@@ -2049,10 +2056,7 @@ impl NodeBase for ContainerNode {
                 (Direction::Down, ContainerSplit::Vertical) => self.children.first_valid(LiveTL),
                 (Direction::Up, ContainerSplit::Vertical) => self.children.last_valid(LiveTL),
                 (Direction::Right, ContainerSplit::Horizontal) => self.children.first_valid(LiveTL),
-                _ => match self.focus_history.last() {
-                    Some(n) => Some(n.deref().clone()),
-                    None => self.children.last_valid(LiveTL),
-                },
+                _ => self.last_focus_or_last(),
             }
         };
         if let Some(node) = node {

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -1520,7 +1520,7 @@ impl ContainerNode {
     fn toggle_mono(self: &Rc<Self>) {
         if self.node_state[LiveTL].mono_child.is_some() {
             self.set_mono(None);
-        } else if let Some(last) = self.focus_history.last() {
+        } else if let Some(last) = self.last_focus_or_last() {
             self.set_mono(Some(&*last.node));
         }
     }

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -38,6 +38,7 @@ use crate::tree::NodeId;
 use crate::tree::NodeLayerLink;
 use crate::tree::NodeLocation;
 use crate::tree::OutputNode;
+use crate::tree::RelativeAxis;
 use crate::tree::SplitView;
 use crate::tree::TddType;
 use crate::tree::TileDragDestination;
@@ -96,6 +97,17 @@ impl ContainerSplit {
         match self {
             ContainerSplit::Horizontal => ContainerSplit::Vertical,
             ContainerSplit::Vertical => ContainerSplit::Horizontal,
+        }
+    }
+
+    pub fn from_relative_axis(axis: RelativeAxis, rect: &Rect) -> Self {
+        let major = match rect.height() > rect.width() {
+            true => ContainerSplit::Vertical,
+            false => ContainerSplit::Horizontal,
+        };
+        match axis {
+            RelativeAxis::Major => major,
+            RelativeAxis::Minor => major.other(),
         }
     }
 }

--- a/src/tree/container.rs
+++ b/src/tree/container.rs
@@ -58,6 +58,7 @@ use crate::tree::toplevel_set_workspace;
 use crate::tree::walker::NodeVisitor;
 use crate::utils::asyncevent::AsyncEvent;
 use crate::utils::bhash::BHashMap;
+use crate::utils::bool_ext::BoolExt;
 use crate::utils::clonecell::CloneCell;
 use crate::utils::double_click_state::DoubleClickState;
 use crate::utils::errorfmt::ErrorFmt;
@@ -1518,11 +1519,12 @@ impl ContainerNode {
     }
 
     fn toggle_mono(self: &Rc<Self>) {
-        if self.node_state[LiveTL].mono_child.is_some() {
-            self.set_mono(None);
-        } else if let Some(last) = self.last_focus_or_last() {
-            self.set_mono(Some(&*last.node));
-        }
+        self.set_own_mono(self.node_state[LiveTL].mono_child.is_none());
+    }
+
+    pub fn set_own_mono(self: &Rc<Self>, mono: bool) {
+        let child = mono.and_then(|| self.last_focus_or_last());
+        self.set_mono(child.as_ref().map(|c| &*c.node));
     }
 
     fn last_focus_or_last(&self) -> Option<NodeRef<ContainerChild>> {

--- a/src/tree/toplevel.rs
+++ b/src/tree/toplevel.rs
@@ -1180,7 +1180,11 @@ pub fn default_tile_drag_bounds<T: ToplevelNodeBase + ?Sized>(t: &T, split: Cont
 }
 
 pub fn toplevel_parent_container(tl: &dyn ToplevelNode) -> Option<Rc<ContainerNode>> {
-    if let Some(parent) = tl.tl_data().parent.get() {
+    toplevel_data_parent_container(tl.tl_data())
+}
+
+pub fn toplevel_data_parent_container(data: &ToplevelData) -> Option<Rc<ContainerNode>> {
+    if let Some(parent) = data.parent.get() {
         return parent.node_into_container();
     }
     None

--- a/src/tree/toplevel.rs
+++ b/src/tree/toplevel.rs
@@ -35,6 +35,7 @@ use crate::state::ConnectorData;
 use crate::state::State;
 use crate::tree::ContainerNode;
 use crate::tree::ContainerSplit;
+use crate::tree::ContainerTarget;
 use crate::tree::ContainingNode;
 use crate::tree::Direction;
 use crate::tree::FloatNode;
@@ -1188,6 +1189,29 @@ pub fn toplevel_data_parent_container(data: &ToplevelData) -> Option<Rc<Containe
         return parent.node_into_container();
     }
     None
+}
+
+pub fn toplevel_target_container(
+    tl: &Rc<dyn ToplevelNode>,
+    target: ContainerTarget,
+) -> Option<Rc<ContainerNode>> {
+    let itself = || tl.clone().node_into_container();
+    let parent = || toplevel_parent_container(&**tl);
+    match target {
+        ContainerTarget::Parent => parent(),
+        ContainerTarget::Itself => itself(),
+        ContainerTarget::Auto => itself().or_else(parent),
+    }
+}
+
+pub fn toplevel_set_target_mono(tl: &Rc<dyn ToplevelNode>, target: ContainerTarget, mono: bool) {
+    let Some(c) = toplevel_target_container(tl, target) else {
+        return;
+    };
+    match c.node_id() == tl.node_id() {
+        true => c.set_own_mono(mono),
+        false => c.set_mono(mono.then_some(&**tl)),
+    }
 }
 
 pub fn toplevel_create_split(state: &Rc<State>, tl: Rc<dyn ToplevelNode>, axis: ContainerSplit) {

--- a/src/tree/toplevel.rs
+++ b/src/tree/toplevel.rs
@@ -1180,10 +1180,8 @@ pub fn default_tile_drag_bounds<T: ToplevelNodeBase + ?Sized>(t: &T, split: Cont
 }
 
 pub fn toplevel_parent_container(tl: &dyn ToplevelNode) -> Option<Rc<ContainerNode>> {
-    if let Some(parent) = tl.tl_data().parent.get()
-        && let Some(container) = parent.node_into_container()
-    {
-        return Some(container);
+    if let Some(parent) = tl.tl_data().parent.get() {
+        return parent.node_into_container();
     }
     None
 }

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -28,6 +28,7 @@ use crate::toml::{self};
 use ahash::AHashMap;
 use counter::CounterSlot;
 use jay_config::Axis;
+use jay_config::ContainerTarget;
 use jay_config::Direction;
 use jay_config::Workspace;
 use jay_config::client::ClientCapabilities;
@@ -91,10 +92,10 @@ pub enum SimpleCommand {
     SetFloating(bool),
     ToggleFullscreen,
     SetFullscreen(bool),
-    ToggleMono,
-    SetMono(bool),
-    ToggleSplit,
-    SetSplit(Axis),
+    ToggleMono(ContainerTarget),
+    SetMono(ContainerTarget, bool),
+    ToggleSplit(ContainerTarget),
+    SetSplit(ContainerTarget, Axis),
     Forward(bool),
     EnableWindowManagement(bool),
     SetFloatAboveFullscreen(bool),

--- a/toml-config/src/config.rs
+++ b/toml-config/src/config.rs
@@ -30,6 +30,7 @@ use counter::CounterSlot;
 use jay_config::Axis;
 use jay_config::ContainerTarget;
 use jay_config::Direction;
+use jay_config::RelativeAxis;
 use jay_config::Workspace;
 use jay_config::client::ClientCapabilities;
 use jay_config::get_overlay;
@@ -124,6 +125,8 @@ pub enum SimpleCommand {
     ToggleVisualizeCompositing,
     SetSplitReusesContainer(bool),
     ToggleSplitReusesContainer,
+    SetSplitRelative(ContainerTarget, RelativeAxis),
+    SplitRelative(RelativeAxis),
 }
 
 #[derive(Debug, Clone)]

--- a/toml-config/src/config/parsers/action.rs
+++ b/toml-config/src/config/parsers/action.rs
@@ -67,6 +67,8 @@ use jay_config::ContainerTarget::Auto;
 use jay_config::ContainerTarget::Itself;
 use jay_config::ContainerTarget::Parent;
 use jay_config::Direction;
+use jay_config::RelativeAxis::Major;
+use jay_config::RelativeAxis::Minor;
 use jay_config::input::LayerDirection;
 use jay_config::input::Timeline;
 use std::rc::Rc;
@@ -162,9 +164,13 @@ impl ActionParser<'_, '_, '_> {
             "move-right" => Move(Right),
             "split-horizontal" => Split(Horizontal),
             "split-vertical" => Split(Vertical),
+            "split-major" => SplitRelative(Major),
+            "split-minor" => SplitRelative(Minor),
             "toggle-split" => ToggleSplit(Parent),
             "tile-horizontal" => SetSplit(Parent, Horizontal),
             "tile-vertical" => SetSplit(Parent, Vertical),
+            "tile-major" => SetSplitRelative(Parent, Major),
+            "tile-minor" => SetSplitRelative(Parent, Minor),
             "toggle-mono" => ToggleMono(Parent),
             "show-single" => SetMono(Parent, true),
             "show-all" => SetMono(Parent, false),
@@ -790,6 +796,12 @@ impl Parser for ActionParser<'_, '_, '_> {
             }
             "tile-vertical" => {
                 self.parse_targeted(&mut ext, |t| SimpleCommand::SetSplit(t, Vertical))
+            }
+            "tile-major" => {
+                self.parse_targeted(&mut ext, |t| SimpleCommand::SetSplitRelative(t, Major))
+            }
+            "tile-minor" => {
+                self.parse_targeted(&mut ext, |t| SimpleCommand::SetSplitRelative(t, Minor))
             }
             "toggle-mono" => self.parse_targeted(&mut ext, SimpleCommand::ToggleMono),
             "show-single" => self.parse_targeted(&mut ext, |t| SimpleCommand::SetMono(t, true)),

--- a/toml-config/src/config/parsers/action.rs
+++ b/toml-config/src/config/parsers/action.rs
@@ -8,6 +8,7 @@ use crate::config::extractor::bol;
 use crate::config::extractor::int;
 use crate::config::extractor::n32;
 use crate::config::extractor::opt;
+use crate::config::extractor::recover;
 use crate::config::extractor::s32;
 use crate::config::extractor::str;
 use crate::config::extractor::val;
@@ -61,6 +62,10 @@ use crate::toml::toml_value::Value;
 use indexmap::IndexMap;
 use jay_config::Axis::Horizontal;
 use jay_config::Axis::Vertical;
+use jay_config::ContainerTarget;
+use jay_config::ContainerTarget::Auto;
+use jay_config::ContainerTarget::Itself;
+use jay_config::ContainerTarget::Parent;
 use jay_config::Direction;
 use jay_config::input::LayerDirection;
 use jay_config::input::Timeline;
@@ -157,12 +162,12 @@ impl ActionParser<'_, '_, '_> {
             "move-right" => Move(Right),
             "split-horizontal" => Split(Horizontal),
             "split-vertical" => Split(Vertical),
-            "toggle-split" => ToggleSplit,
-            "tile-horizontal" => SetSplit(Horizontal),
-            "tile-vertical" => SetSplit(Vertical),
-            "toggle-mono" => ToggleMono,
-            "show-single" => SetMono(true),
-            "show-all" => SetMono(false),
+            "toggle-split" => ToggleSplit(Parent),
+            "tile-horizontal" => SetSplit(Parent, Horizontal),
+            "tile-vertical" => SetSplit(Parent, Vertical),
+            "toggle-mono" => ToggleMono(Parent),
+            "show-single" => SetMono(Parent, true),
+            "show-all" => SetMono(Parent, false),
             "toggle-fullscreen" => ToggleFullscreen,
             "enter-fullscreen" => SetFullscreen(true),
             "exit-fullscreen" => SetFullscreen(false),
@@ -223,6 +228,26 @@ impl ActionParser<'_, '_, '_> {
             }
         };
         Ok(Action::SimpleCommand { cmd })
+    }
+
+    fn parse_targeted(
+        &mut self,
+        ext: &mut Extractor<'_, '_, '_>,
+        f: impl FnOnce(ContainerTarget) -> SimpleCommand,
+    ) -> ParseResult<Self> {
+        let target = ext.extract(recover(opt(str("target"))))?;
+        let mut container_target = Parent;
+        if let Some(target) = target {
+            match target.value {
+                "parent" => container_target = Parent,
+                "self" => container_target = Itself,
+                "auto" => container_target = Auto,
+                _ => log::error!("Unknown target: {}", self.0.error3(target.span)),
+            }
+        }
+        Ok(Action::SimpleCommand {
+            cmd: f(container_target),
+        })
     }
 
     fn parse_multi(&mut self, _span: Span, array: &[Spanned<Value>]) -> ParseResult<Self> {
@@ -759,6 +784,16 @@ impl Parser for ActionParser<'_, '_, '_> {
             "remove-virtual-output" => self.parse_remove_virtual_output(&mut ext),
             "resize" => self.parse_resize(&mut ext),
             "hide-overlay" => self.parse_hide_overlay(&mut ext),
+            "toggle-split" => self.parse_targeted(&mut ext, SimpleCommand::ToggleSplit),
+            "tile-horizontal" => {
+                self.parse_targeted(&mut ext, |t| SimpleCommand::SetSplit(t, Horizontal))
+            }
+            "tile-vertical" => {
+                self.parse_targeted(&mut ext, |t| SimpleCommand::SetSplit(t, Vertical))
+            }
+            "toggle-mono" => self.parse_targeted(&mut ext, SimpleCommand::ToggleMono),
+            "show-single" => self.parse_targeted(&mut ext, |t| SimpleCommand::SetMono(t, true)),
+            "show-all" => self.parse_targeted(&mut ext, |t| SimpleCommand::SetMono(t, false)),
             "show-overlay" => self.parse_show_overlay(&mut ext),
             "toggle-overlay" => self.parse_toggle_overlay(&mut ext),
             "inc-counter" => self.parse_adj_counter(&mut ext, false),

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -264,6 +264,12 @@ impl Action {
                 SimpleCommand::SetSplit(t, b) => {
                     window_or_seat!(s, s.set_container_split(t, b))
                 }
+                SimpleCommand::SplitRelative(axis) => {
+                    window_or_seat!(s, s.create_split_relative(axis))
+                }
+                SimpleCommand::SetSplitRelative(t, axis) => {
+                    window_or_seat!(s, s.set_container_split_relative(t, axis))
+                }
                 SimpleCommand::ToggleMono(t) => window_or_seat!(s, s.toggle_container_mono(t)),
                 SimpleCommand::SetMono(t, b) => window_or_seat!(s, s.set_container_mono(t, b)),
                 SimpleCommand::ToggleFullscreen => window_or_seat!(s, s.toggle_fullscreen()),

--- a/toml-config/src/lib.rs
+++ b/toml-config/src/lib.rs
@@ -258,10 +258,14 @@ impl Action {
                 SimpleCommand::Focus(dir) => b.new(move || s.focus(dir)),
                 SimpleCommand::Move(dir) => window_or_seat!(s, s.move_(dir)),
                 SimpleCommand::Split(axis) => window_or_seat!(s, s.create_split(axis)),
-                SimpleCommand::ToggleSplit => window_or_seat!(s, s.toggle_split()),
-                SimpleCommand::SetSplit(b) => window_or_seat!(s, s.set_split(b)),
-                SimpleCommand::ToggleMono => window_or_seat!(s, s.toggle_mono()),
-                SimpleCommand::SetMono(b) => window_or_seat!(s, s.set_mono(b)),
+                SimpleCommand::ToggleSplit(t) => {
+                    window_or_seat!(s, s.toggle_container_split(t))
+                }
+                SimpleCommand::SetSplit(t, b) => {
+                    window_or_seat!(s, s.set_container_split(t, b))
+                }
+                SimpleCommand::ToggleMono(t) => window_or_seat!(s, s.toggle_container_mono(t)),
+                SimpleCommand::SetMono(t, b) => window_or_seat!(s, s.set_container_mono(t, b)),
                 SimpleCommand::ToggleFullscreen => window_or_seat!(s, s.toggle_fullscreen()),
                 SimpleCommand::SetFullscreen(b) => window_or_seat!(s, s.set_fullscreen(b)),
                 SimpleCommand::FocusParent => b.new(move || s.focus_parent()),

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -2297,7 +2297,7 @@
     },
     "SimpleActionName": {
       "type": "string",
-      "description": "The name of a `simple` Action.\n\nWhen used inside a window rule, the following actions apply to the matched window\ninstead fo the focused window:\n\n- `move-left`\n- `move-down`\n- `move-up`\n- `move-right`\n- `split-horizontal`\n- `split-vertical`\n- `toggle-split`\n- `tile-horizontal`\n- `tile-vertical`\n- `toggle-split`\n- `show-single`\n- `show-all`\n- `toggle-fullscreen`\n- `enter-fullscreen`\n- `exit-fullscreen`\n- `close`\n- `toggle-floating`\n- `float`\n- `tile`\n- `toggle-float-pinned`\n- `pin-float`\n- `unpin-float`\n\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-q = \"quit\"\n  ```\n",
+      "description": "The name of a `simple` Action.\n\nWhen used inside a window rule, the following actions apply to the matched window\ninstead of the focused window:\n\n- `move-left`\n- `move-down`\n- `move-up`\n- `move-right`\n- `split-horizontal`\n- `split-vertical`\n- `toggle-split`\n- `tile-horizontal`\n- `tile-vertical`\n- `toggle-mono`\n- `show-single`\n- `show-all`\n- `toggle-fullscreen`\n- `enter-fullscreen`\n- `exit-fullscreen`\n- `close`\n- `toggle-floating`\n- `float`\n- `tile`\n- `toggle-float-pinned`\n- `pin-float`\n- `unpin-float`\n\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-q = \"quit\"\n  ```\n",
       "enum": [
         "focus-left",
         "focus-down",

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -841,6 +841,38 @@
               ]
             },
             {
+              "description": "Sets the split of the target container along its larger dimension.\nThat is, to vertical if the container is higher than it is wide and\nto horizontal otherwise.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-a = { type = \"tile-major\", target = \"self\" }\n  ```\n",
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "tile-major"
+                },
+                "target": {
+                  "description": "The container the action applies to.\n\nThe default is `parent`.\n",
+                  "$ref": "#/$defs/ContainerTarget"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "description": "Sets the split of the target container along its smaller dimension.\nThat is, to horizontal if the container is higher than it is wide and\nto vertical otherwise.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-a = { type = \"tile-minor\", target = \"self\" }\n  ```\n",
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "tile-minor"
+                },
+                "target": {
+                  "description": "The container the action applies to.\n\nThe default is `parent`.\n",
+                  "$ref": "#/$defs/ContainerTarget"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
               "description": "Toggle the target container between showing a single and all\nchildren.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-a = { type = \"toggle-mono\", target = \"self\" }\n  ```\n",
               "type": "object",
               "properties": {
@@ -2402,7 +2434,7 @@
     },
     "SimpleActionName": {
       "type": "string",
-      "description": "The name of a `simple` Action.\n\nWhen used inside a window rule, the following actions apply to the matched window\ninstead of the focused window:\n\n- `move-left`\n- `move-down`\n- `move-up`\n- `move-right`\n- `split-horizontal`\n- `split-vertical`\n- `toggle-split`\n- `tile-horizontal`\n- `tile-vertical`\n- `toggle-mono`\n- `show-single`\n- `show-all`\n- `toggle-fullscreen`\n- `enter-fullscreen`\n- `exit-fullscreen`\n- `close`\n- `toggle-floating`\n- `float`\n- `tile`\n- `toggle-float-pinned`\n- `pin-float`\n- `unpin-float`\n\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-q = \"quit\"\n  ```\n",
+      "description": "The name of a `simple` Action.\n\nWhen used inside a window rule, the following actions apply to the matched window\ninstead of the focused window:\n\n- `move-left`\n- `move-down`\n- `move-up`\n- `move-right`\n- `split-horizontal`\n- `split-vertical`\n- `split-major`\n- `split-minor`\n- `toggle-split`\n- `tile-horizontal`\n- `tile-vertical`\n- `tile-major`\n- `tile-minor`\n- `toggle-mono`\n- `show-single`\n- `show-all`\n- `toggle-fullscreen`\n- `enter-fullscreen`\n- `exit-fullscreen`\n- `close`\n- `toggle-floating`\n- `float`\n- `tile`\n- `toggle-float-pinned`\n- `pin-float`\n- `unpin-float`\n\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-q = \"quit\"\n  ```\n",
       "enum": [
         "focus-left",
         "focus-down",
@@ -2415,9 +2447,13 @@
         "move-right",
         "split-horizontal",
         "split-vertical",
+        "split-major",
+        "split-minor",
         "toggle-split",
         "tile-horizontal",
         "tile-vertical",
+        "tile-major",
+        "tile-minor",
         "toggle-mono",
         "show-single",
         "show-all",

--- a/toml-spec/spec/spec.generated.json
+++ b/toml-spec/spec/spec.generated.json
@@ -791,6 +791,102 @@
                 "name",
                 "value"
               ]
+            },
+            {
+              "description": "Toggle the split of the target container between vertical and\nhorizontal.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-a = { type = \"toggle-split\", target = \"self\" }\n  ```\n",
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "toggle-split"
+                },
+                "target": {
+                  "description": "The container the action applies to.\n\nThe default is `parent`.\n",
+                  "$ref": "#/$defs/ContainerTarget"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "description": "Sets the split of the target container to horizontal.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-a = { type = \"tile-horizontal\", target = \"self\" }\n  ```\n",
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "tile-horizontal"
+                },
+                "target": {
+                  "description": "The container the action applies to.\n\nThe default is `parent`.\n",
+                  "$ref": "#/$defs/ContainerTarget"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "description": "Sets the split of the target container to vertical.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-a = { type = \"tile-vertical\", target = \"self\" }\n  ```\n",
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "tile-vertical"
+                },
+                "target": {
+                  "description": "The container the action applies to.\n\nThe default is `parent`.\n",
+                  "$ref": "#/$defs/ContainerTarget"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "description": "Toggle the target container between showing a single and all\nchildren.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-a = { type = \"toggle-mono\", target = \"self\" }\n  ```\n",
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "toggle-mono"
+                },
+                "target": {
+                  "description": "The container the action applies to.\n\nThe default is `parent`.\n",
+                  "$ref": "#/$defs/ContainerTarget"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "description": "Makes the target container show a single child.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-a = { type = \"show-single\", target = \"self\" }\n  ```\n",
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "show-single"
+                },
+                "target": {
+                  "description": "The container the action applies to.\n\nThe default is `parent`.\n",
+                  "$ref": "#/$defs/ContainerTarget"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "description": "Makes the target container show all children.\n\n- Example:\n\n  ```toml\n  [shortcuts]\n  alt-a = { type = \"show-all\", target = \"self\" }\n  ```\n",
+              "type": "object",
+              "properties": {
+                "type": {
+                  "const": "show-all"
+                },
+                "target": {
+                  "description": "The container the action applies to.\n\nThe default is `parent`.\n",
+                  "$ref": "#/$defs/ContainerTarget"
+                }
+              },
+              "required": [
+                "type"
+              ]
             }
           ]
         }
@@ -1434,6 +1530,15 @@
         "separators",
         "full",
         "full-smart"
+      ]
+    },
+    "ContainerTarget": {
+      "type": "string",
+      "description": "The container that an action applies to.\n",
+      "enum": [
+        "parent",
+        "self",
+        "auto"
       ]
     },
     "ContentTypeMask": {

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -1122,6 +1122,134 @@ This table is a tagged union. The variant is determined by the `type` field. It 
 
     The numbers should be integers.
 
+- `toggle-split`:
+
+  Toggle the split of the target container between vertical and
+  horizontal.
+  
+  - Example:
+  
+    ```toml
+    [shortcuts]
+    alt-a = { type = "toggle-split", target = "self" }
+    ```
+
+  The table has the following fields:
+
+  - `target` (optional):
+
+    The container the action applies to.
+    
+    The default is `parent`.
+
+    The value of this field should be a [ContainerTarget](#types-ContainerTarget).
+
+- `tile-horizontal`:
+
+  Sets the split of the target container to horizontal.
+  
+  - Example:
+  
+    ```toml
+    [shortcuts]
+    alt-a = { type = "tile-horizontal", target = "self" }
+    ```
+
+  The table has the following fields:
+
+  - `target` (optional):
+
+    The container the action applies to.
+    
+    The default is `parent`.
+
+    The value of this field should be a [ContainerTarget](#types-ContainerTarget).
+
+- `tile-vertical`:
+
+  Sets the split of the target container to vertical.
+  
+  - Example:
+  
+    ```toml
+    [shortcuts]
+    alt-a = { type = "tile-vertical", target = "self" }
+    ```
+
+  The table has the following fields:
+
+  - `target` (optional):
+
+    The container the action applies to.
+    
+    The default is `parent`.
+
+    The value of this field should be a [ContainerTarget](#types-ContainerTarget).
+
+- `toggle-mono`:
+
+  Toggle the target container between showing a single and all
+  children.
+  
+  - Example:
+  
+    ```toml
+    [shortcuts]
+    alt-a = { type = "toggle-mono", target = "self" }
+    ```
+
+  The table has the following fields:
+
+  - `target` (optional):
+
+    The container the action applies to.
+    
+    The default is `parent`.
+
+    The value of this field should be a [ContainerTarget](#types-ContainerTarget).
+
+- `show-single`:
+
+  Makes the target container show a single child.
+  
+  - Example:
+  
+    ```toml
+    [shortcuts]
+    alt-a = { type = "show-single", target = "self" }
+    ```
+
+  The table has the following fields:
+
+  - `target` (optional):
+
+    The container the action applies to.
+    
+    The default is `parent`.
+
+    The value of this field should be a [ContainerTarget](#types-ContainerTarget).
+
+- `show-all`:
+
+  Makes the target container show all children.
+  
+  - Example:
+  
+    ```toml
+    [shortcuts]
+    alt-a = { type = "show-all", target = "self" }
+    ```
+
+  The table has the following fields:
+
+  - `target` (optional):
+
+    The container the action applies to.
+    
+    The default is `parent`.
+
+    The value of this field should be a [ContainerTarget](#types-ContainerTarget).
+
 
 <a name="types-BarPosition"></a>
 ### `BarPosition`
@@ -2848,6 +2976,31 @@ The string should have one of the following values:
   A border is drawn around the entire container, in addition to the separators
   between children, unless the container has only one child and is the root
   container of the workspace.
+
+
+
+<a name="types-ContainerTarget"></a>
+### `ContainerTarget`
+
+The container that an action applies to.
+
+Values of this type should be strings.
+
+The string should have one of the following values:
+
+- `parent`:
+
+  The parent container of the window. This is the default.
+
+- `self`:
+
+  The window itself.
+  
+  The action has no effect if the window is not a container.
+
+- `auto`:
+
+  The window itself if it is a container, otherwise its parent container.
 
 
 

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -4920,7 +4920,7 @@ The table has the following fields:
 The name of a `simple` Action.
 
 When used inside a window rule, the following actions apply to the matched window
-instead fo the focused window:
+instead of the focused window:
 
 - `move-left`
 - `move-down`
@@ -4931,7 +4931,7 @@ instead fo the focused window:
 - `toggle-split`
 - `tile-horizontal`
 - `tile-vertical`
-- `toggle-split`
+- `toggle-mono`
 - `show-single`
 - `show-all`
 - `toggle-fullscreen`

--- a/toml-spec/spec/spec.generated.md
+++ b/toml-spec/spec/spec.generated.md
@@ -1186,6 +1186,52 @@ This table is a tagged union. The variant is determined by the `type` field. It 
 
     The value of this field should be a [ContainerTarget](#types-ContainerTarget).
 
+- `tile-major`:
+
+  Sets the split of the target container along its larger dimension.
+  That is, to vertical if the container is higher than it is wide and
+  to horizontal otherwise.
+  
+  - Example:
+  
+    ```toml
+    [shortcuts]
+    alt-a = { type = "tile-major", target = "self" }
+    ```
+
+  The table has the following fields:
+
+  - `target` (optional):
+
+    The container the action applies to.
+    
+    The default is `parent`.
+
+    The value of this field should be a [ContainerTarget](#types-ContainerTarget).
+
+- `tile-minor`:
+
+  Sets the split of the target container along its smaller dimension.
+  That is, to horizontal if the container is higher than it is wide and
+  to vertical otherwise.
+  
+  - Example:
+  
+    ```toml
+    [shortcuts]
+    alt-a = { type = "tile-minor", target = "self" }
+    ```
+
+  The table has the following fields:
+
+  - `target` (optional):
+
+    The container the action applies to.
+    
+    The default is `parent`.
+
+    The value of this field should be a [ContainerTarget](#types-ContainerTarget).
+
 - `toggle-mono`:
 
   Toggle the target container between showing a single and all
@@ -5081,9 +5127,13 @@ instead of the focused window:
 - `move-right`
 - `split-horizontal`
 - `split-vertical`
+- `split-major`
+- `split-minor`
 - `toggle-split`
 - `tile-horizontal`
 - `tile-vertical`
+- `tile-major`
+- `tile-minor`
 - `toggle-mono`
 - `show-single`
 - `show-all`
@@ -5154,6 +5204,16 @@ The string should have one of the following values:
 
   Split the currently focused window vertically.
 
+- `split-major`:
+
+  Split the currently focused window along its larger dimension. That is,
+  vertically if the window is higher than it is wide and horizontally otherwise.
+
+- `split-minor`:
+
+  Split the currently focused window along its smaller dimension. That is,
+  horizontally if the window is higher than it is wide and vertically otherwise.
+
 - `toggle-split`:
 
   Toggle the split of the currently focused container between vertical and
@@ -5166,6 +5226,18 @@ The string should have one of the following values:
 - `tile-vertical`:
 
   Sets the split of the currently focused container to vertical.
+
+- `tile-major`:
+
+  Sets the split of the currently focused container along its larger dimension.
+  That is, to vertical if the container is higher than it is wide and to
+  horizontal otherwise.
+
+- `tile-minor`:
+
+  Sets the split of the currently focused container along its smaller dimension.
+  That is, to horizontal if the container is higher than it is wide and to
+  vertical otherwise.
 
 - `toggle-mono`:
 

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -1145,7 +1145,7 @@ SimpleActionName:
     The name of a `simple` Action.
     
     When used inside a window rule, the following actions apply to the matched window
-    instead fo the focused window:
+    instead of the focused window:
     
     - `move-left`
     - `move-down`
@@ -1156,7 +1156,7 @@ SimpleActionName:
     - `toggle-split`
     - `tile-horizontal`
     - `tile-vertical`
-    - `toggle-split`
+    - `toggle-mono`
     - `show-single`
     - `show-all`
     - `toggle-fullscreen`

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -1079,6 +1079,46 @@ Action:
                 The container the action applies to.
 
                 The default is `parent`.
+        tile-major:
+          description: |
+            Sets the split of the target container along its larger dimension.
+            That is, to vertical if the container is higher than it is wide and
+            to horizontal otherwise.
+
+            - Example:
+
+              ```toml
+              [shortcuts]
+              alt-a = { type = "tile-major", target = "self" }
+              ```
+          fields:
+            target:
+              ref: ContainerTarget
+              required: false
+              description: |
+                The container the action applies to.
+
+                The default is `parent`.
+        tile-minor:
+          description: |
+            Sets the split of the target container along its smaller dimension.
+            That is, to horizontal if the container is higher than it is wide and
+            to vertical otherwise.
+
+            - Example:
+
+              ```toml
+              [shortcuts]
+              alt-a = { type = "tile-minor", target = "self" }
+              ```
+          fields:
+            target:
+              ref: ContainerTarget
+              required: false
+              description: |
+                The container the action applies to.
+
+                The default is `parent`.
         toggle-mono:
           description: |
             Toggle the target container between showing a single and all
@@ -1281,9 +1321,13 @@ SimpleActionName:
     - `move-right`
     - `split-horizontal`
     - `split-vertical`
+    - `split-major`
+    - `split-minor`
     - `toggle-split`
     - `tile-horizontal`
     - `tile-vertical`
+    - `tile-major`
+    - `tile-minor`
     - `toggle-mono`
     - `show-single`
     - `show-all`
@@ -1329,6 +1373,14 @@ SimpleActionName:
       description: Split the currently focused window horizontally.
     - value: split-vertical
       description: Split the currently focused window vertically.
+    - value: split-major
+      description: |
+        Split the currently focused window along its larger dimension. That is,
+        vertically if the window is higher than it is wide and horizontally otherwise.
+    - value: split-minor
+      description: |
+        Split the currently focused window along its smaller dimension. That is,
+        horizontally if the window is higher than it is wide and vertically otherwise.
     - value: toggle-split
       description: |
         Toggle the split of the currently focused container between vertical and
@@ -1337,6 +1389,16 @@ SimpleActionName:
       description: Sets the split of the currently focused container to horizontal.
     - value: tile-vertical
       description: Sets the split of the currently focused container to vertical.
+    - value: tile-major
+      description: |
+        Sets the split of the currently focused container along its larger dimension.
+        That is, to vertical if the container is higher than it is wide and to
+        horizontal otherwise.
+    - value: tile-minor
+      description: |
+        Sets the split of the currently focused container along its smaller dimension.
+        That is, to horizontal if the container is higher than it is wide and to
+        vertical otherwise.
     - value: toggle-mono
       description: |
         Toggle the currently focused container between showing a single and all children.

--- a/toml-spec/spec/spec.yaml
+++ b/toml-spec/spec/spec.yaml
@@ -1024,6 +1024,134 @@ Action:
               required: true
               kind: number
               integer_only: true
+        toggle-split:
+          description: |
+            Toggle the split of the target container between vertical and
+            horizontal.
+
+            - Example:
+
+              ```toml
+              [shortcuts]
+              alt-a = { type = "toggle-split", target = "self" }
+              ```
+          fields:
+            target:
+              ref: ContainerTarget
+              required: false
+              description: |
+                The container the action applies to.
+
+                The default is `parent`.
+        tile-horizontal:
+          description: |
+            Sets the split of the target container to horizontal.
+
+            - Example:
+
+              ```toml
+              [shortcuts]
+              alt-a = { type = "tile-horizontal", target = "self" }
+              ```
+          fields:
+            target:
+              ref: ContainerTarget
+              required: false
+              description: |
+                The container the action applies to.
+
+                The default is `parent`.
+        tile-vertical:
+          description: |
+            Sets the split of the target container to vertical.
+
+            - Example:
+
+              ```toml
+              [shortcuts]
+              alt-a = { type = "tile-vertical", target = "self" }
+              ```
+          fields:
+            target:
+              ref: ContainerTarget
+              required: false
+              description: |
+                The container the action applies to.
+
+                The default is `parent`.
+        toggle-mono:
+          description: |
+            Toggle the target container between showing a single and all
+            children.
+
+            - Example:
+
+              ```toml
+              [shortcuts]
+              alt-a = { type = "toggle-mono", target = "self" }
+              ```
+          fields:
+            target:
+              ref: ContainerTarget
+              required: false
+              description: |
+                The container the action applies to.
+
+                The default is `parent`.
+        show-single:
+          description: |
+            Makes the target container show a single child.
+
+            - Example:
+
+              ```toml
+              [shortcuts]
+              alt-a = { type = "show-single", target = "self" }
+              ```
+          fields:
+            target:
+              ref: ContainerTarget
+              required: false
+              description: |
+                The container the action applies to.
+
+                The default is `parent`.
+        show-all:
+          description: |
+            Makes the target container show all children.
+
+            - Example:
+
+              ```toml
+              [shortcuts]
+              alt-a = { type = "show-all", target = "self" }
+              ```
+          fields:
+            target:
+              ref: ContainerTarget
+              required: false
+              description: |
+                The container the action applies to.
+
+                The default is `parent`.
+
+
+ContainerTarget:
+  description: |
+    The container that an action applies to.
+  kind: string
+  values:
+    - value: parent
+      description: |
+        The parent container of the window. This is the default.
+    - value: self
+      description: |
+        The window itself.
+
+        The action has no effect if the window is not a container.
+    - value: auto
+      description: |
+        The window itself if it is a container, otherwise its parent container.
 
 
 Exec:


### PR DESCRIPTION
Adds a `target` parameter to all container actions to operate on the node itself (`self`), the parent node (`parent`) or the node itself if it is a container and its parent otherwise (`auto`); discussed in https://github.com/mahkoh/jay/pull/1176.

Adds `split-major` / `split-minor` / `tile-major` / `tile-minor` actions which derive their split / tile direction from the geometry, i.e. the ratio of targets width and height. 