### PR TITLE
xwindow: reset window extents when destroying xwindow

### DIFF
--- a/src/ifs/wl_surface/x_surface/xwindow.rs
+++ b/src/ifs/wl_surface/x_surface/xwindow.rs
@@ -255,6 +255,7 @@ impl Xwindow {
     pub fn destroy(self: &Rc<Self>) {
         self.break_loops();
         self.data.window.take();
+        self.data.info.extents.take();
     }
 
     pub fn break_loops(self: &Rc<Self>) {


### PR DESCRIPTION
Fixes #1215 